### PR TITLE
romove Apache PID file if it's still there

### DIFF
--- a/orcidhub-core/run-app
+++ b/orcidhub-core/run-app
@@ -74,6 +74,6 @@ chown -R apache:apache /var/log/orcidhub
 # Run Shibboleth and Apache:
 echo "Starting Shibboleth ..."
 /etc/shibboleth/shibd-redhat start
-rm -f /usr/local/apache2/logs/httpd.pid /var/lock/subsys/shibd
+rm -f /run/httpd/httpd.pid /usr/local/apache2/logs/httpd.pid /var/lock/subsys/shibd
 echo "Starting Apache2 ..."
 exec httpd -DFOREGROUND


### PR DESCRIPTION
After restarting the app container, if Apache didn't go down properly, PID file doesn't get deleted. Apache cannot start. The PID file should be deleted.