### PR TITLE
Minor change to credential request

### DIFF
--- a/authcontroller.py
+++ b/authcontroller.py
@@ -316,7 +316,7 @@ def orcid_callback():
         error_description = request.args.get("error_description")
         if error == "access_denied":
             flash("You have denied the Hub access to your ORCID record."
-                  " The Hub needs at least read access to your profile to be useful.", "danger")
+                  " At a minimum, the Hub needs to know your ORCID iD to be useful.", "danger")
         else:
             flash("Error occured while attempting to authorize '%s': %s" %
                   (current_user.organisation.name, error_description), "danger")

--- a/authcontroller.py
+++ b/authcontroller.py
@@ -428,7 +428,7 @@ def orcid_callback():
                 "The ORCID Hub was not able to automatically write an affiliation with %s, "
                 "as the nature of the affiliation with your organisation does not appear to include either "
                 "Employment or Education.\n"
-                "Please contact one of your Organisaiton Administrator if you believe this is an error."
+                "Please contact your Organisation Administrator(s) if you believe this is an error."
                 % orciduser.organisation, "danger")
 
     session['Should_not_logout_from_ORCID'] = True

--- a/authcontroller.py
+++ b/authcontroller.py
@@ -717,7 +717,7 @@ def update_org_info():
             contact_name=user.name,
             org_name=user.organisation.name,
             cred_type=CRED_TYPE_PREMIUM,
-            app_name=APP_NAME + " at " + user.organisation.name,
+            app_name=user.organisation.name,
             app_description=APP_DESCRIPTION + " at " + user.organisation.name,
             app_url=APP_URL,
             redirect_uri_1=redirect_uri))

--- a/templates/linking.html
+++ b/templates/linking.html
@@ -6,13 +6,13 @@
     </p>
     {% if error=='access_denied' %}
         <p>The Hub is requesting write access in order to affirm your relationship with {{current_user.organisation.name}} in your ORCID record.</p>
-        <p>If you'd like to grant this access, click <a id="connect-orcid-button_write_permission_error" class="btn btn-default" href="{{orcid_url_write}}" role="button"><img id="orcid-id-logo_write_permission_error" src="https://orcid.org/sites/default/files/images/orcid_24x24.png"
-                     width='24' height='24' alt="ORCID logo"/>&nbsp;here</a> to try again.</p>
-        <p>If you only wish to make {{current_user.organisation.name}} a trusted-party, i.e., able to read from but not write to your record, click <a id="connect-orcid-button_read_permission" class="btn btn-default" href="{{orcid_url_read_limited}}" role="button"><img id="orcid-id-logo_read_limited" src="https://orcid.org/sites/default/files/images/orcid_24x24.png"
-                     width='24' height='24' alt="ORCID logo"/>&nbsp;here</a>.</p>
-        <p>If you only want to let {{current_user.organisation.name}} know your ORCID iD and read your public content, click <a id="connect-orcid-button_authenticate" class="btn btn-default" href="{{orcid_url_authenticate}}" role="button"><img id="orcid-id-logo_authenticate" src="https://orcid.org/sites/default/files/images/orcid_24x24.png"
-                     width='24' height='24' alt="ORCID logo"/>&nbsp;here</a>.</p>
-        <p>If you don't want to give {{current_user.organisation.name}} any permission to your ORCID record, simply log out of the hub.</p>
+        <p>If you'd like to grant this access, click here: <a id="connect-orcid-button_write_permission_error" class="btn btn-default" href="{{orcid_url_write}}" role="button"><img id="orcid-id-logo_write_permission_error" src="https://orcid.org/sites/default/files/images/orcid_24x24.png"
+                     width='24' height='24' alt="ORCID logo"/></a> to try again.</p>
+        <p>If you only wish to make {{current_user.organisation.name}} a trusted-party, i.e., able to read from but not write to your record, click here to: <a id="connect-orcid-button_read_permission" class="btn btn-default" href="{{orcid_url_read_limited}}" role="button"><img id="orcid-id-logo_read_limited" src="https://orcid.org/sites/default/files/images/orcid_24x24.png"
+                     width='24' height='24' alt="ORCID logo"/>&nbsp;grant&nbsp;read-limited&nbsp;permission</a>.</p>
+        <p>If you only want to let {{current_user.organisation.name}} know your ORCID iD and read your public content, click here to: <a id="connect-orcid-button_authenticate" class="btn btn-default" href="{{orcid_url_authenticate}}" role="button"><img id="orcid-id-logo_authenticate" src="https://orcid.org/sites/default/files/images/orcid_24x24.png"
+                     width='24' height='24' alt="ORCID logo"/>&nbsp;authenticate&nbsp;your&nbsp;ORCID id</a>.</p>
+        <p>If you don't want to give {{current_user.organisation.name}} any permission to your ORCID record, simply log out of the Hub.</p>
     {% else %}
         <p>
             <a id="connect-orcid-button_write_permission" class="btn btn-default" role="button" onclick="logoutOrcid()">


### PR DESCRIPTION
Early advice was for the Hub to clearly ID itself in the integrations that it supports, i.e.,  with an Application Name like "NZ ORCID Hub for Royal Society".  Since then the practice has changed to being a little less cluttered.  (Unless we instruct them otherwise) the ORCID team will just trim the app_name to being the organisation.name anyway so let's not send anything else.