### PR TITLE
"alum" doesn't imply education affilation

### DIFF
--- a/authcontroller.py
+++ b/authcontroller.py
@@ -172,7 +172,7 @@ def handle_login():
         edu_person_affiliation = Affiliation.NONE
         if unscoped_affiliation & {"faculty", "staff"}:
             edu_person_affiliation |= Affiliation.EMP
-        if unscoped_affiliation & {"student", "alum"}:
+        if unscoped_affiliation & {"student"}:
             edu_person_affiliation |= Affiliation.EDU
         if not edu_person_affiliation:
             flash(


### PR DESCRIPTION
eduPersonAffiliation contains "alum" doesn't imply an education affilation for all Tuakiri members, some use it in a way that would seem to be better met by "affiliate" but we can't change the facts.  
Until we've identified which orgs are using it to mean graduate, we have to pull