### PR TITLE
Expanding descriptions and highlighting responsibilities

### DIFF
--- a/templates/affiliation_record_list.html
+++ b/templates/affiliation_record_list.html
@@ -48,7 +48,8 @@
     <form class="icon" method="POST"
                        action="{{url_for('activate_all')}}">
       <input id="task_id" name="task_id" type="hidden" value="{{task.id}}">
-      <button onclick="return safeConfirm('Are you sure you want to activate every record in this batch for processing?');"
+      <button onclick="return safeConfirm('Are you sure you want to activate every record in this batch for processing?\n\nBy clicking &quot;OK&quot;'+
+              ' you are affirming that the affiliations to be written are, to the \nbest of your knowledge, correct!');"
               data-toggle="tooltip" data-placement="bottom"
               title="Activate all records for batch processing..." class="btn btn-info">Activate all
       </button>

--- a/templates/fileUpload.html
+++ b/templates/fileUpload.html
@@ -8,7 +8,7 @@
             <h1>{{ form_title }} Info Upload</h1>
               {{ form.hidden_tag() }}
               {{ render_field(form.file_) }}
-              <span class="pull-right">
+              <span class="pull-right" style="padding-bottom: 40px;">
                 <button type="submit" class="btn btn-primary" value="Save">Upload</button>
               </span>
         </form>
@@ -35,16 +35,16 @@
           <li>Department</li>
           <li>City: if different to your home campus's city otherwise that will be used</li>
           <li>Region</li>
-          <li>Course or Title; for an education item, the course of study or degree name, for an employment item, </li>
-          <li>Start date;</li>
-          <li>End date;</li>
-          <li>Country; ISO 3166-1 alpha-2 and if different to your home campus's country code otherwise that will be used, i.e. NZ.</li>
-          <li>Disambiguation ID; if different to your home campus's ID, the identifier for the Organisation that is given by the accompanying Disambiguation Source</li>
-          <li>Disambiguation Source; typically RINGGOLD or Fundref, and required if a Disambiguation ID is provided</li>
+          <li>Course or Title: for an education item, the course of study or degree name; for an employment item, the role or job title</li>
+          <li>Start date: Affiliation start date in ISO 8601 format, to the known/desired level of precision</li>
+          <li>End date: Affiliation end date in ISO 8601 format, leave blank or omit field for ongoing affiliations</li>
+          <li>Country: ISO 3166-1 alpha-2 and if different to your home campus's country code otherwise that will be used, i.e. NZ.</li>
+          <li>Disambiguation ID: if different to your home campus's ID, the identifier for the Organisation that is given by the accompanying Disambiguation Source</li>
+          <li>Disambiguation Source: typically RINGGOLD or Fundref, and required if a Disambiguation ID is provided</li>
         </ul>
         <li>To update existing ORCID items</li>
         <ul>
-          <li>Put-Code; this is a code ORCID uses to identify the item and is returned to you in the Hub's affiliation report. </br>
+          <li>Put-Code: this is a code ORCID uses to identify the item and is returned to you in the Hub's affiliation report. </br>
           With a put-code the Hub attempts to overwrite an item; while without one, a new item is created with a new put-code</li>
         </ul>
       </ul>

--- a/templates/fileUpload.html
+++ b/templates/fileUpload.html
@@ -17,30 +17,42 @@
     {% if request.endpoint == "load_researcher_affiliations" %}
     <div class="row">
       <div class="col-md-12 col-sm-12 col-xs-12">
-      <p>Please format your affiliation data as a comma-separated or tab-separated text file, with the first row being the headers matching any of the following allowed fields:</p>
+      <p>Please format your affiliation data as a comma-separated or tab-separated text file.</br>
+      The first row of the file must contain only headers matching any of the following allowed field names:</p>
       <ul>
-        <li>Identifier (optional);</li>
-        <li>First name;</li>
-        <li>Last name;</li>
-        <li>Email;</li>
-        <li>ORCID iD;</li>
-        <li>Organisation;</li>
-        <li>Department;</li>
-        <li>City;</li>
-        <li>Region;</li>
-        <li>Course or Title;</li>
-        <li>Start date;</li>
-        <li>End date;</li>
-        <li>Affiliation type;</li>
-        <li>Country;</li>
-        <li>Disambiguation ID;</li>
-        <li>Disambiguation Source.</li>
+        <li>Required:</li>
+        <ul>
+          <li>Affiliation type: i.e., a value to indicate whether to write the affiliation to education or employment e.g., "staff" or "student"</li>
+          <li>Email: the institutional email for the individual, and where the invitation will be sent if they're not known by the Hub</li>
+          <li>First name: if the user does not have an ORCID iD, this field together with 'Last name' and email, will be used to pre-fill ORCID registration</li>
+          <li>Last name</li>
+        </ul>
+        <li>Optional:</li>
+        <ul>
+          <li>Identifier: this can be any identifier used in your internal systems and is to allow you to match the resulting put-code from ORCID simplifying updates to the item</li>
+          <li>ORCID iD: once it has been authenticated, an ORCID iD can be used instead of an email address; however, without an email address any invitation required cannot be sent</li>
+          <li>Organisation: if different to your home campus. NB you may only write affiliations for organisations that are related to the member, e.g., historic names and subsidiaries</li>
+          <li>Department</li>
+          <li>City: if different to your home campus's city otherwise that will be used</li>
+          <li>Region</li>
+          <li>Course or Title; for an education item, the course of study or degree name, for an employment item, </li>
+          <li>Start date;</li>
+          <li>End date;</li>
+          <li>Country; ISO 3166-1 alpha-2 and if different to your home campus's country code otherwise that will be used, i.e. NZ.</li>
+          <li>Disambiguation ID; if different to your home campus's ID, the identifier for the Organisation that is given by the accompanying Disambiguation Source</li>
+          <li>Disambiguation Source; typically RINGGOLD or Fundref, and required if a Disambiguation ID is provided</li>
+        </ul>
+        <li>To update existing ORCID items</li>
+        <ul>
+          <li>Put-Code; this is a code ORCID uses to identify the item and is returned to you in the Hub's affiliation report. </br>
+          With a put-code the Hub attempts to overwrite an item; while without one, a new item is created with a new put-code</li>
+        </ul>
       </ul>
       <p>
-      The affiliation file must contain either an email address or, if an individual has already gone through the Hub, an ORCID iD.<br>Dates must be given in ISO format, <strong>YYYY-MM-DD</strong> but partial dates are accepted, e.g, dates of: "2017", "2017-12", and "2017-12-15" are all valid.</p>
-      <p>
-      Where a field header or value is not provided, the value from your organisation will be used if it's available, e.g., City, Country, Disambiguation ID, and Disambiguation Source can be omitted where redundant.</p>
-      <p>The minimum affiliation file should have: First name; Last name; Email; and Affiliation type.</p>
+      Note: each record in the the affiliation file must contain either an email address or, <strong>if</strong> an individual has already gone through the Hub, an ORCID iD.</br>
+      Dates must be given in ISO 8601 format, i.e., <strong>YYYY-MM-DD</strong> with partial dates accepted, e.g, "2017", "2017-12", and "2017-12-15" are all valid.</br>
+      Where a field header or value is not provided, the value from your organisation will be used if it's available, e.g., Organisation, City, Country, Disambiguation ID, </br>
+      and Disambiguation Source can be omitted where redundant.</p>
       </div>
     </div>
   {% endif %}

--- a/templates/header.html
+++ b/templates/header.html
@@ -54,9 +54,6 @@
                                     data-toggle="tooltip" data-placement="bottom"
                                                           title="Affiliate yourself using the NZ ORCID HUB or view your ORCID iD">Your ORCID</span></a></li>
                 {% if current_user.has_role("ADMIN") %}
-                  <!-- Functionality to be added post-launch
-                    <li id="researcher"><a href="#">Register Researcher(s)</a></li>
-                  -->
                   <li class="dropdown">
                     <a class="dropdown-toggle" data-toggle="dropdown" href="#">Affiliations<span class="caret"></span></a>
                     <ul class="dropdown-menu">

--- a/views.py
+++ b/views.py
@@ -440,7 +440,7 @@ class AffiliationRecordAdmin(AppModelView):
         return super().get_export_name(export_type=export_type)
 
     @action("activate", "Activate for processing",
-            "Are you sure you want to activate the selected records for batch processing?\n\nBy clicking \"OK\" "+
+            "Are you sure you want to activate the selected records for batch processing?\n\nBy clicking \"OK\" " +
             "you are affirming that the affiliations to be written are, to the\n best of your knowledge, correct!")
     def action_activate(self, ids):
         """Batch registraion of users."""

--- a/views.py
+++ b/views.py
@@ -440,7 +440,8 @@ class AffiliationRecordAdmin(AppModelView):
         return super().get_export_name(export_type=export_type)
 
     @action("activate", "Activate for processing",
-            "Are you sure you want to activate the selected records for batch processing?")
+            "Are you sure you want to activate the selected records for batch processing?\n\nBy clicking \"OK\" "+
+            "you are affirming that the affiliations to be written are, to the\n best of your knowledge, correct!")
     def action_activate(self, ids):
         """Batch registraion of users."""
         try:


### PR DESCRIPTION
A bunch of misc changes
- mostly to do with emphasizing that the admin/tech contact 
has a responsibility to make sure the affiliations to be written are correct.
- adding full(er) descriptions to the affiliation fields in fileUpload