### PR TITLE
Orcidhub 175

### DIFF
--- a/.conda.yml
+++ b/.conda.yml
@@ -11,27 +11,32 @@ dependencies:
 - wheel
 - zlib
 - pip:
+  - emails
+  - fake-factory
+  - Flask
+  - flask-admin
+  - flask-debugtoolbar
+  - flask-login
+  - flask_mail
+  - Flask-OAuthlib
+  - flask-peewee
+  - flask-swagger
+  - Flask-WTF
+  - html2text
+  - peewee
+  - peewee-validates
+  - psycopg2
+  - pycountry
+  - pykwalify
+  - python-slugify
+  - pyyaml
+  - raven
+  - raven[flask]
+  - recommonmark
+  - requests
+  - requests_oauthlib
   - sphinx
   - sphinx-autobuild
-  - recommonmark
-  - pyyaml 
-  - coverage>=4.4.1
-  - coveralls>=1.2.0
-  - fake-factory>=9999.9.9
-  - flake8>=3.4.1
-  - flake8-docstrings>=1.1.0
-  - flake8-polyfill>=1.0.1
-  - flask-debugtoolbar>=0.10.1
-  - isort>=4.2.15
-  - mccabe>=0.6.1
-  - pep8-naming>=0.4.1
-  - pycodestyle>=2.3.1
-  - pydocs>=0.2
-  - pydocstyle>=2.0.0
-  - pyflakes>=1.5.0
-  - Pygments>=2.2.0
-  - pytest>=3.2.1
-  - pytest-cov>=2.5.1
-  - six>=1.10.0
-  - testpath>=0.3.1
-  - yapf>=0.17.0
+  - tablib
+  - testpath
+  - wtf-peewee

--- a/docs/orcid_hub.rst
+++ b/docs/orcid_hub.rst
@@ -36,14 +36,6 @@ orcid\_hub\.config module
     :undoc-members:
     :show-inheritance:
 
-orcid\_hub\.conftest module
----------------------------
-
-.. automodule:: orcid_hub.conftest
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 orcid\_hub\.failover module
 ---------------------------
 
@@ -108,61 +100,6 @@ orcid\_hub\.reports module
     :undoc-members:
     :show-inheritance:
 
-orcid\_hub\.test\_forms module
-------------------------------
-
-.. automodule:: orcid_hub.test_forms
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-orcid\_hub\.test\_main module
------------------------------
-
-.. automodule:: orcid_hub.test_main
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-orcid\_hub\.test\_models module
--------------------------------
-
-.. automodule:: orcid_hub.test_models
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-orcid\_hub\.test\_orcid module
-------------------------------
-
-.. automodule:: orcid_hub.test_orcid
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-orcid\_hub\.test\_reports module
---------------------------------
-
-.. automodule:: orcid_hub.test_reports
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-orcid\_hub\.test\_utils module
-------------------------------
-
-.. automodule:: orcid_hub.test_utils
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-orcid\_hub\.test\_views module
-------------------------------
-
-.. automodule:: orcid_hub.test_views
-    :members:
-    :undoc-members:
-    :show-inheritance:
 
 orcid\_hub\.utils module
 ------------------------

--- a/run_pytest.sh
+++ b/run_pytest.sh
@@ -8,6 +8,6 @@ export FLASK_APP=orcid_hub
 export LANG=en_US.UTF-8
 
 ##   flask process
-export DATABASE_URL="sqlite:///:memory:" 
-export EXTERNAL_SP='' 
-pytest --ignore=venv --ignore=orcid_api -s -v --cov-config .coveragerc  --cov . orcid_hub/test_*.py
+export DATABASE_URL="sqlite:///:memory:"
+export EXTERNAL_SP=''
+pytest --ignore=venv --ignore=orcid_api -s -v --cov-config .coveragerc  --cov . tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 # flake8: noqa
-from . import config
+from orcid_hub import config
 DATABASE_URL = os.environ.get("TEST_DATABASE_URL") or "sqlite:///:memory:"
 config.DATABASE_URL = DATABASE_URL
 os.environ["DATABASE_URL"] = DATABASE_URL
@@ -20,12 +20,12 @@ import pytest
 from playhouse import db_url
 from playhouse.test_utils import test_database
 
-from . import app as _app
+from orcid_hub import app as _app
 _app.config["DATABASE_URL"] = DATABASE_URL
-from .models import *  # noqa: F401, F403
-from .authcontroller import *  # noqa: F401, F403
-from .views import *  # noqa: F401, F403
-from .reports import *  # noqa: F401, F403
+from orcid_hub.models import *  # noqa: F401, F403
+from orcid_hub.authcontroller import *  # noqa: F401, F403
+from orcid_hub.views import *  # noqa: F401, F403
+from orcid_hub.reports import *  # noqa: F401, F403
 
 db = _app.db = _db = db_url.connect(DATABASE_URL, autorollback=True)
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -7,9 +7,9 @@ from unittest.mock import MagicMock
 import pytest
 from wtforms import Form, StringField
 
-from .forms import validate_orcid_id_field  # noqa: E128
-from .forms import (BitmapMultipleValueField, CountrySelectField, PartialDate, PartialDateField)
-from .models import PartialDate as PartialDateDbField
+from orcid_hub.forms import validate_orcid_id_field  # noqa: E128
+from orcid_hub.forms import (BitmapMultipleValueField, CountrySelectField, PartialDate, PartialDateField)
+from orcid_hub.models import PartialDate as PartialDateDbField
 
 
 def test_partial_date_widget():  # noqa

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,8 +6,8 @@ import pprint
 import pytest
 from flask_login import login_user
 
-from . import login_provider, utils
-from .models import Organisation, OrgInfo, OrgInvitation, Role, User, UserOrg
+from orcid_hub import login_provider, utils
+from orcid_hub.models import Organisation, OrgInfo, OrgInvitation, Role, User, UserOrg
 
 
 def test_index(client):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,9 +4,9 @@ import pytest
 from peewee import Model, SqliteDatabase
 from playhouse.test_utils import test_database
 
-from .models import (Affiliation, AffiliationRecord, ModelException, OrcidToken, Organisation,
-                     OrgInfo, PartialDate, PartialDateField, Role, Task, User, UserOrg,
-                     UserOrgAffiliation, create_tables, drop_tables)
+from orcid_hub.models import (Affiliation, AffiliationRecord, ModelException, OrcidToken,
+                              Organisation, OrgInfo, PartialDate, PartialDateField, Role, Task,
+                              User, UserOrg, UserOrgAffiliation, create_tables, drop_tables)
 
 
 @pytest.fixture

--- a/tests/test_orcid.py
+++ b/tests/test_orcid.py
@@ -10,7 +10,7 @@ import requests_oauthlib
 from flask import session, url_for
 from flask_login import login_user
 
-from .models import Affiliation, OrcidToken, Organisation, User, UserOrg
+from orcid_hub.models import Affiliation, OrcidToken, Organisation, User, UserOrg
 
 fake_time = time.time()
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from flask_login import login_user
 
-from .models import Organisation, Role, User, UserOrg
+from orcid_hub.models import Organisation, Role, User, UserOrg
 
 
 def test_admin_view_access(request_ctx):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,8 @@
 
 from flask_login import login_user
 
-from . import utils
-from .models import Organisation, Role, User, UserOrg
+from orcid_hub import utils
+from orcid_hub.models import Organisation, Role, User, UserOrg
 
 
 def test_append_qs():

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -12,10 +12,10 @@ from flask_login import login_user
 from peewee import SqliteDatabase
 from playhouse.test_utils import test_database
 
-from . import orcid_client, views
-from .config import ORCID_BASE_URL
-from .models import UserOrgAffiliation  # noqa: E128
-from .models import (AffiliationRecord, OrcidToken, Organisation, Role, Task, User, UserOrg)
+from orcid_hub import orcid_client, views
+from orcid_hub.config import ORCID_BASE_URL
+from orcid_hub.models import UserOrgAffiliation  # noqa: E128
+from orcid_hub.models import (AffiliationRecord, OrcidToken, Organisation, Role, Task, User, UserOrg)
 
 fake_time = time.time()
 


### PR DESCRIPTION
 - excluded tests from the docs;
 - added env so that docs can be automatically generated;
 - registered domain for docs: http://docs.orcidhub.org.nz
 - ported doc about the setting dev environment using package: http://docs.orcidhub.org.nz/en/latest/development_env.html