### PR TITLE
Adding changes for removing the funding record from batch process if …

### DIFF
--- a/orcid_hub/utils.py
+++ b/orcid_hub/utils.py
@@ -427,8 +427,11 @@ def create_or_update_funding(user, org_id, records, *args, **kwargs):
             except Exception as ex:
                 logger.exception(f"For {user} encountered exception")
                 fc.add_status_line(f"Exception occured processing the record: {ex}.")
+                fr.add_status_line(f"Exception occured processing the record: {ex}.")
+                fc.processed_at = datetime.now()
 
             finally:
+                fr.save()
                 fc.save()
     else:
         # TODO: Invitation resend in case user revokes organisation permissions
@@ -761,7 +764,7 @@ def process_funding_records(max_rows=20):
                     FundingContributor.processed_at.is_null()).exists()):
                 funding_record.processed_at = datetime.now()
                 funding_record.add_status_line(
-                    f"Funding record is processed, and now the funding record will appear on contributors profile"
+                    f"Funding record is processed."
                 )
                 funding_record.save()
 


### PR DESCRIPTION
…there is an exception occured while making a ORCID call, the admin will get an email saying, there was an error in processing and then he can make necessary changes and reset the funding record, this functionality will help us to avoid making call to orcid every minute in case of exception.