### PR TITLE
the authorisation decorator should be placed behind the route decorator

### DIFF
--- a/orcid_hub/views.py
+++ b/orcid_hub/views.py
@@ -1610,12 +1610,12 @@ def logo_image(token=None):
     return redirect(url_for("static", filename="images/banner-small.png", _external=True))
 
 
-@roles_required(Role.TECHNICAL, Role.ADMIN)
 @app.route(
     "/settings/logo", methods=[
         "GET",
         "POST",
     ])
+@roles_required(Role.TECHNICAL, Role.ADMIN)
 def logo():
     """Manage organisation 'logo'."""
     org = current_user.organisation


### PR DESCRIPTION
fix for:
https://sentry.io/royal-society-of-new-zealand/test/issues/438028082/

