### PR TITLE
Only do the bitwise XOR in case if superuser is present in roles, oth…

### DIFF
--- a/orcid_hub/models.py
+++ b/orcid_hub/models.py
@@ -644,7 +644,8 @@ class User(BaseModel, UserMixin, AuditMixin):
         """Sets user as a HUB admin."""
         if value:
             self.roles |= Role.SUPERUSER
-        else:
+        # Only do the bitwise XOR in case if superuser is present in roles,otherwise superuser gets set in user edit.
+        elif bool(self.roles & Role.SUPERUSER):
             self.roles ^= Role.SUPERUSER
 
     @property


### PR DESCRIPTION
…erwise on every edit and save of user from flask admin view the 'is superuser' checkbox gets toggle.