### PR TITLE
fixed spelling in the model module

### DIFF
--- a/orcid_hub/models.py
+++ b/orcid_hub/models.py
@@ -731,13 +731,13 @@ class User(BaseModel, UserMixin, AuditMixin):
             return Affiliation.NONE
 
     def is_tech_contact_of(self, org=None):
-        """Indicates if the user is the technical contact of the organisation."""
+        """Indicate if the user is the technical contact of the organisation."""
         if org is None:
             org = self.organisation
         return org and org.tech_contact and org.tech_contact_id == self.id
 
     def is_admin_of(self, org=None):
-        """Indicates if the user is the technical contact of the organisation."""
+        """Indicate if the user is the technical contact of the organisation."""
         if org is None:
             org = self.organisation
         return org and UserOrg.select().where(UserOrg.user == self, UserOrg.org == org, UserOrg.is_admin).exists()

--- a/orcid_hub/models.py
+++ b/orcid_hub/models.py
@@ -51,7 +51,7 @@ AFFILIATION_TYPES = (
 
 
 class ModelException(Exception):
-    """Applicaton model exception."""
+    """Application model exception."""
 
     pass
 
@@ -280,7 +280,7 @@ class Affiliation(IntFlag):
 
 
 class BaseModel(Model):
-    """Encapsulate commont bits and pieces of the model classes."""
+    """Encapsulate common bits and pieces of the model classes."""
 
     def field_is_updated(self, field_name):
         """Test if field is 'dirty'."""
@@ -368,7 +368,7 @@ DeferredUser = ModelDeferredRelation()
 
 
 class AuditMixin(Model):
-    """Mixing for getting data necessary for data change audit trail maintenace."""
+    """Mixing for getting data necessary for data change audit trail maintenance."""
 
     created_at = DateTimeField(default=datetime.utcnow)
     updated_at = DateTimeField(null=True, default=None)
@@ -400,7 +400,7 @@ class File(BaseModel):
 
 
 class Organisation(BaseModel, AuditMixin):
-    """Research oranisation."""
+    """Research organisation."""
 
     country_choices = [(c.alpha_2, c.name) for c in countries]
     country_choices.sort(key=lambda e: e[1])
@@ -473,14 +473,14 @@ class Organisation(BaseModel, AuditMixin):
 
     @property
     def admins(self):
-        """Get organisation's adminstrator query."""
+        """Get organisation's administrator query."""
         return self.users.where(UserOrg.is_admin)
 
     def __repr__(self):
         return self.name or self.tuakiri_name
 
     def save(self, *args, **kwargs):
-        """Handle data consitency validation and saving."""
+        """Handle data consistency validation and saving."""
         if self.is_dirty():
 
             if self.name is None:
@@ -591,7 +591,7 @@ class User(BaseModel, UserMixin, AuditMixin):
     """
     ORCiD Hub user.
 
-    It's a gneric user including researchers, organisation administrators, hub administrators, etc.
+    It's a generic user including researchers, organisation administrators, hub administrators, etc.
     """
 
     name = CharField(max_length=64, null=True)
@@ -599,7 +599,6 @@ class User(BaseModel, UserMixin, AuditMixin):
     last_name = CharField(null=True, verbose_name="Last Name")
     email = CharField(max_length=120, unique=True, null=True, verbose_name="Email Address")
     eppn = CharField(max_length=120, unique=True, null=True, verbose_name="EPPN")
-    # ORCiD:
     orcid = OrcidIdField(null=True, verbose_name="ORCID iD", help_text="User's ORCID iD")
     confirmed = BooleanField(default=False)
     # Role bit-map:
@@ -610,8 +609,8 @@ class User(BaseModel, UserMixin, AuditMixin):
     orcid_updated_at = DateTimeField(null=True, default=None)
 
     # TODO: many-to-many
-    # NB! depricated!
-    # TODO: we still need to rememeber the rognanistiaon that last authenticated the user
+    # NB! Deprecated!
+    # TODO: we still need to remember the organisation that last authenticated the user
     organisation = ForeignKeyField(
         Organisation, related_name="members", on_delete="SET NULL", null=True)
     created_by = ForeignKeyField(DeferredUser, on_delete="SET NULL", null=True)
@@ -633,7 +632,7 @@ class User(BaseModel, UserMixin, AuditMixin):
 
     @lazy_property
     def org_links(self):
-        """Get all user organisation linked direct and undirect."""
+        """Get all user organisation linked directly and indirectly."""
         if self.orcid:
             q = UserOrg.select().join(
                 User,
@@ -668,8 +667,8 @@ class User(BaseModel, UserMixin, AuditMixin):
     def is_active(self):
         """Get 'is_active' based on confirmed for Flask-Login.
 
-        TODO: confirmed - user that email is cunfimed either by IdP or by confirmation email
-        ins't the same as "is active".
+        TODO: confirmed - user that email is confirmed either by IdP or by confirmation email
+        isn't the same as "is active".
         """
         return self.confirmed
 
@@ -732,20 +731,20 @@ class User(BaseModel, UserMixin, AuditMixin):
             return Affiliation.NONE
 
     def is_tech_contact_of(self, org=None):
-        """Indicats if the user is the technical contact of the organisation."""
+        """Indicates if the user is the technical contact of the organisation."""
         if org is None:
             org = self.organisation
         return org and org.tech_contact and org.tech_contact_id == self.id
 
     def is_admin_of(self, org=None):
-        """Indicats if the user is the technical contact of the organisation."""
+        """Indicates if the user is the technical contact of the organisation."""
         if org is None:
             org = self.organisation
         return org and UserOrg.select().where(UserOrg.user == self, UserOrg.org == org, UserOrg.is_admin).exists()
 
     @property
     def uuid(self):
-        """Generate UUID for the user basee on the the primary email."""
+        """Generate UUID for the user based on the primary email."""
         return uuid.uuid5(uuid.NAMESPACE_URL, "mailto:" + (self.email or self.eppn))
 
 
@@ -767,7 +766,7 @@ class OrgInvitation(BaseModel, AuditMixin):
     confirmed_at = DateTimeField(null=True)
     tech_contact = BooleanField(
         null=True,
-        help_text="The invitee is the techical contact of the organisation.",
+        help_text="The invitee is the technical contact of the organisation.",
         verbose_name="Is Tech.contact")
     url = CharField(null=True)
 
@@ -802,9 +801,9 @@ class UserOrg(BaseModel, AuditMixin):
     # access_token = CharField(max_length=120, unique=True, null=True)
 
     def save(self, *args, **kwargs):
-        """Enforce foriegn key contraints and consolidate user roles with the linked organisations.
+        """Enforce foreign key constraints and consolidate user roles with the linked organisations.
 
-        Enforce foriegn key contraints and consolidate user roles with the linked organisations
+        Enforce foreign key constraints and consolidate user roles with the linked organisations
         before saving data.
         """
         if self.is_dirty():
@@ -830,7 +829,7 @@ class UserOrg(BaseModel, AuditMixin):
 
 
 class OrcidToken(BaseModel, AuditMixin):
-    """For Keeping Orcid token in the table."""
+    """For Keeping ORCID token in the table."""
 
     user = ForeignKeyField(
         User, null=True, index=True,
@@ -971,12 +970,12 @@ class Task(BaseModel, AuditMixin):
 
     @lazy_property
     def completed_count(self):
-        """Get number of completd rows."""
+        """Get number of completed rows."""
         return self.records.where(self.record_model.processed_at.is_null(False)).count()
 
     @lazy_property
     def completed_percent(self):
-        """Get the percentaage of completd rows."""
+        """Get the percentage of completed rows."""
         return (100. * self.completed_count) / self.record_count if self.record_count else 0.
 
     @property
@@ -1060,7 +1059,7 @@ class Task(BaseModel, AuditMixin):
                     external_id = val(row, 16)
 
                     if not email and not orcid and external_id and validators.email(external_id):
-                        # if email is missing and exernal ID is given as a valid email, use it:
+                        # if email is missing and external ID is given as a valid email, use it:
                         email = external_id
 
                     # The uploaded country must be from ISO 3166-1 alpha-2
@@ -1199,7 +1198,7 @@ class UserInvitation(BaseModel, AuditMixin):
 
 
 class RecordModel(BaseModel):
-    """Commond model bits of the task records."""
+    """Common model bits of the task records."""
 
     def save(self, *args, **kwargs):
         """Update related batch task when changing the record."""
@@ -1215,7 +1214,7 @@ class RecordModel(BaseModel):
 
     @classmethod
     def get_field_regxes(cls):
-        """Retun map of compliled field name regex to the model fields."""
+        """Return map of compiled field name regex to the model fields."""
         return {f: re.compile(e, re.I) for (f, e) in cls._field_regex_map}
 
 
@@ -1313,7 +1312,7 @@ class AffiliationRecord(RecordModel):
 class TaskType(IntEnum):
     """Enum used to represent Task type."""
 
-    AFFILIATION = 0  # Affilation of employment/education
+    AFFILIATION = 0  # Affiliation of employment/education
     FUNDING = 1  # Funding
     WORK = 2
     PEER_REVIEW = 3
@@ -1331,12 +1330,12 @@ class TaskType(IntEnum):
 
     @classmethod
     def options(cls):
-        """Get list of all types for UI dropown option list."""
+        """Get list of all types for UI drop-down option list."""
         return [(e.value, e.name.replace('_', ' ').title()) for e in cls]
 
 
 class FundingRecord(RecordModel):
-    """Funding record loaded from Json file for batch processing."""
+    """Funding record loaded from JSON file for batch processing."""
 
     task = ForeignKeyField(Task, related_name="funding_records", on_delete="CASCADE")
     title = CharField(max_length=255)
@@ -1361,7 +1360,7 @@ class FundingRecord(RecordModel):
     status = TextField(null=True, help_text="Record processing status.")
 
     def to_export_dict(self):
-        """Map the funding record to dict for exprt into JSON/YAML."""
+        """Map the funding record to dict for export into JSON/YAML."""
         org = self.task.org
         d = {
             "type": self.type,
@@ -1591,8 +1590,8 @@ class FundingRecord(RecordModel):
 
     @classmethod
     def load_from_json(cls, source, filename=None, org=None, task=None):
-        """Load data from json file or a string."""
-        # import data from file based on its extension; either it is yaml or json
+        """Load data from JSON file or a string."""
+        # import data from file based on its extension; either it is YAML or JSON
         data = load_yaml_json(filename=filename, source=source)
         records = data["records"] if isinstance(data, dict) else data
 
@@ -1600,7 +1599,7 @@ class FundingRecord(RecordModel):
             validation_source_data = copy.deepcopy(r)
             validation_source_data = del_none(validation_source_data)
 
-            # Adding schema valdation for funding
+            # Adding schema validation for funding
             validator = Core(
                 source_data=validation_source_data,
                 schema_files=[os.path.join(SCHEMA_DIR, "funding_schema.yaml")])
@@ -1956,7 +1955,7 @@ class PeerReviewRecord(RecordModel):
     def load_from_json(cls, source, filename=None, org=None):
         """Load data from JSON file or a string."""
         if isinstance(source, str):
-            # import data from file based on its extension; either it is yaml or json
+            # import data from file based on its extension; either it is YAML or JSON
             peer_review_data_list = load_yaml_json(filename=filename, source=source)
 
             for peer_review_data in peer_review_data_list:
@@ -2375,7 +2374,7 @@ class WorkRecord(RecordModel):
     def load_from_json(cls, source, filename=None, org=None):
         """Load data from JSON file or a string."""
         if isinstance(source, str):
-            # import data from file based on its extension; either it is yaml or json
+            # import data from file based on its extension; either it is YAML or JSON
             work_data_list = load_yaml_json(filename=filename, source=source)
 
             # TODO: validation of uploaded work file
@@ -2383,7 +2382,7 @@ class WorkRecord(RecordModel):
                 validation_source_data = copy.deepcopy(work_data)
                 validation_source_data = del_none(validation_source_data)
 
-                # Adding schema valdation for Work
+                # Adding schema validation for Work
                 validator = Core(
                     source_data=validation_source_data,
                     schema_files=[os.path.join(SCHEMA_DIR, "work_schema.yaml")])
@@ -2514,7 +2513,7 @@ class ContributorModel(BaseModel):
     email = CharField(max_length=120, null=True)
 
     def to_export_dict(self):
-        """Map the contributor record to dict for exprt into JSON/YAML."""
+        """Map the contributor record to dict for export into JSON/YAML."""
         return {
                 "contributor-attributes": {"contributor-role": self.role},
                 "contributor-email": dict(value=self.email),
@@ -2534,14 +2533,14 @@ class WorkContributor(ContributorModel):
         table_alias = "wc"
 
     def to_export_dict(self):
-        """Map the contributor record to dict for exprt into JSON/YAML."""
+        """Map the contributor record to dict for export into JSON/YAML."""
         d = super().to_export_dict()
         d["contributor-attributes"].update({"contributor-sequence": self.contributor_sequence})
         return d
 
 
 class FundingContributor(ContributorModel):
-    """Researcher or contributor - reciever of the funding."""
+    """Researcher or contributor - receiver of the funding."""
 
     funding_record = ForeignKeyField(
         FundingRecord, related_name="contributors", on_delete="CASCADE")
@@ -2565,7 +2564,7 @@ class InviteesModel(BaseModel):
     processed_at = DateTimeField(null=True)
 
     def save(self, *args, **kwargs):
-        """Consitency validation and saving."""
+        """Consistency validation and saving."""
         if self.is_dirty() and self.email and self.field_is_updated("email"):
             self.email = self.email.lower()
         return super().save(*args, **kwargs)
@@ -2694,7 +2693,7 @@ class Url(BaseModel, AuditMixin):
 
     @classmethod
     def shorten(cls, url):
-        """Create a shorten url or retrievs an exiting one."""
+        """Create a shorten URL or retrieves an exiting one."""
         try:
             u = cls.get(url=url)
         except cls.DoesNotExist:
@@ -2860,7 +2859,7 @@ class Token(BaseModel):
 
 
 def readup_file(input_file):
-    """Read up the whole content and deconde it and return the whole content."""
+    """Read up the whole content and decode it and return the whole content."""
     raw = input_file.read()
     for encoding in "utf-8-sig", "utf-8", "utf-16":
         try:
@@ -2945,7 +2944,7 @@ def drop_tables():
 
 
 def load_yaml_json(filename, source):
-    """Create a common way of loading json or yaml file."""
+    """Create a common way of loading JSON or YAML file."""
     _, ext = os.path.splitext(filename)
     if ext.lower() in [".yaml", ".yml"]:
         data = yaml.load(source)


### PR DESCRIPTION
I couldn't reproduce the issue. But I noticed that constraint that ensure that there are not duplicates was created. It was added the model a while after it was first rolled out. I have added manually and made sure there weren't any duplicates. As it turned out the neither production DB nor TEST DB didn't have any. The dev DB had a single duplicate:

```
DELETE FROM user_org WHERE id NOT IN (SELECT max(id) FROM user_org GROUP BY user_id, org_id);
CREATE UNIQUE INDEX user_org_user_id_org_id ON public.user_org USING btree (user_id, org_id);
```

I reckon it has something to do with the specific browser.