### PR TITLE
Orcidhub 427/428

### DIFF
--- a/orcid_hub/authcontroller.py
+++ b/orcid_hub/authcontroller.py
@@ -811,6 +811,8 @@ def onboard_org():
                 flash("Organisation information updated successfully!", "success")
 
             form.populate_obj(organisation)
+            organisation.disambiguated_id = organisation.disambiguated_id.strip()
+            organisation.disambiguation_source = organisation.disambiguation_source.strip()
             organisation.api_credentials_entered_at = datetime.utcnow()
             try:
                 organisation.save()

--- a/orcid_hub/static/css/style.css
+++ b/orcid_hub/static/css/style.css
@@ -283,6 +283,11 @@ table.permissions, table.permissions th, table.permissions td, table.users, tabl
     margin: 0 12px;
 }
 
+.form-horizontal .form-group {
+    margin-top: 15px;
+    margin-right: 20%;
+}
+
 #connect-orcid-button{
 	border: 1px solid #D3D3D3;
 	padding: .3em;

--- a/orcid_hub/static/css/style.css
+++ b/orcid_hub/static/css/style.css
@@ -285,7 +285,8 @@ table.permissions, table.permissions th, table.permissions td, table.users, tabl
 
 .form-horizontal .form-group {
     margin-top: 15px;
-    margin-right: 20%;
+    margin-right: 40%;
+    margin-left: 10%;
 }
 
 #connect-orcid-button{

--- a/orcid_hub/templates/admin/master.html
+++ b/orcid_hub/templates/admin/master.html
@@ -11,9 +11,7 @@ The extension based on the version v1.5.#}
 {% endblock %}
 {% block page_body %}
   {% include 'header.html' %}
-  <div class="container">
-    {% block messages %}{{ layout.messages() }}{% endblock %}
-
+  <div class="container-fluid">
     {# store the jinja2 context for form_rules rendering logic #}
     {% set render_ctx = h.resolve_ctx() %}
 


### PR DESCRIPTION
making the flask Admin form nicer and removing leading and trailing whitespace in disambiguation info