### PR TITLE
Orcidhub 451/454

### DIFF
--- a/orcid_hub/models.py
+++ b/orcid_hub/models.py
@@ -1165,7 +1165,7 @@ class Task(BaseModel, AuditMixin):
                        r"start\s*(date)?", r"end\s*(date)?",
                        r"affiliation(s)?\s*(type)?|student|staff", "country", r"disambiguat.*id",
                        r"disambiguat.*source", r"put|code", "orcid.*", "external.*|.*identifier",
-                       "delete(.*record)?", ]
+                       "delete(.*record)?", r"(is)?\s*visib(bility|le)?", ]
         ]
 
         def index(rex):
@@ -1258,7 +1258,12 @@ class Task(BaseModel, AuditMixin):
                             "Wrong number of fields. Expected at least 4 fields "
                             "(first name, last name, email address or another unique identifier, "
                             f"student/staff): {row}")
-
+                    disambiguation_source = val(row, 13)
+                    if disambiguation_source:
+                        disambiguation_source = disambiguation_source.upper()
+                    visibility = val(row, 18)
+                    if visibility:
+                        visibility = visibility.upper()
                     af = AffiliationRecord(
                         task=task,
                         first_name=first_name,
@@ -1274,11 +1279,12 @@ class Task(BaseModel, AuditMixin):
                         affiliation_type=affiliation_type,
                         country=country,
                         disambiguated_id=val(row, 12),
-                        disambiguation_source=val(row, 13),
+                        disambiguation_source=disambiguation_source,
                         put_code=put_code,
                         orcid=orcid,
                         external_id=external_id,
-                        delete_record=delete_record)
+                        delete_record=delete_record,
+                        visibility=visibility,)
                     validator = ModelValidator(af)
                     if not validator.validate():
                         raise ModelException(f"Invalid record: {validator.errors}")
@@ -1586,10 +1592,15 @@ class AffiliationRecord(RecordModel):
                         if k == "id":
                             continue
                         k = k.replace('-', '_')
+                        if k in ["visibility", "disambiguation_source"] and v:
+                            v = v.upper()
                         if k in record_fields and rec._data.get(k) != v:
                             rec._data[k] = PartialDate.create(v) if k.endswith("date") else v
                             rec._dirty.add(k)
                     if rec.is_dirty():
+                        validator = ModelValidator(rec)
+                        if not validator.validate():
+                            raise ModelException(f"Invalid record: {validator.errors}")
                         rec.save()
             except:
                 db.rollback()

--- a/orcid_hub/models.py
+++ b/orcid_hub/models.py
@@ -1526,6 +1526,7 @@ class AffiliationRecord(RecordModel):
         verbose_name="Disambiguation Source",
         choices=disambiguation_source_choices)
     delete_record = BooleanField(null=True)
+    visibility = CharField(null=True, max_length=100, choices=visibility_choices)
 
     class Meta:  # noqa: D101,D106
         db_table = "affiliation_record"

--- a/orcid_hub/orcid_client.py
+++ b/orcid_hub/orcid_client.py
@@ -1050,6 +1050,7 @@ class MemberAPI(MemberAPIV20Api):
             end_date=None,
             put_code=None,
             initial=False,
+            visibility=None,
             *args,
             **kwargs):
         """Create or update affiliation record of a user.
@@ -1112,6 +1113,9 @@ class MemberAPI(MemberAPIV20Api):
         if put_code:
             rec.put_code = put_code
 
+        if visibility:
+            rec.visibility = visibility
+
         rec.department_name = department
         rec.role_title = role or course_or_role
 
@@ -1139,11 +1143,13 @@ class MemberAPI(MemberAPIV20Api):
                 try:
                     orcid, put_code = location.split("/")[-3::2]
                     put_code = int(put_code)
+                    visibility = None
                 except Exception:
                     app.logger.exception("Failed to get ORCID iD/put-code from the response.")
                     raise Exception("Failed to get ORCID iD/put-code from the response.")
             elif resp.status == 200:
                 orcid = self.user.orcid
+                visibility = json.loads(resp.data).get("visibility") if hasattr(resp, "data") else None
 
         except ApiException as apiex:
             app.logger.exception(f"For {self.user} encountered exception: {apiex}")
@@ -1152,7 +1158,7 @@ class MemberAPI(MemberAPIV20Api):
             app.logger.exception(f"For {self.user} encountered exception")
             raise ex
         else:
-            return (put_code, orcid, created)
+            return (put_code, orcid, created, visibility)
 
     def create_or_update_researcher_url(self, name=None, value=None, display_index=None, orcid=None,
                                         put_code=None, visibility=None, *args, **kwargs):

--- a/orcid_hub/orcid_client.py
+++ b/orcid_hub/orcid_client.py
@@ -300,8 +300,9 @@ class MemberAPI(MemberAPIV20Api):
         if put_code:
             rec.put_code = pi.put_code
 
-        if pi.visibility:
-            rec.visibility = pi.visibility
+        visibility = pi.visibility
+        if visibility:
+            rec.visibility = visibility
 
         external_id_list = []
         external_ids = PeerReviewExternalId.select().where(
@@ -341,13 +342,13 @@ class MemberAPI(MemberAPIV20Api):
                 try:
                     orcid, put_code = location.split("/")[-3::2]
                     put_code = int(put_code)
-                    pi.put_code = put_code
-                    pi.save()
+                    visibility = None
                 except:
                     app.logger.exception("Failed to get ORCID iD/put-code from the response.")
                     raise Exception("Failed to get ORCID iD/put-code from the response.")
             elif resp.status == 200:
                 orcid = self.user.orcid
+                visibility = json.loads(resp.data).get("visibility") if hasattr(resp, "data") else None
 
         except ApiException as ex:
             if ex.status == 404:
@@ -359,7 +360,7 @@ class MemberAPI(MemberAPIV20Api):
         except:
             app.logger.exception(f"For {self.user} encountered exception")
         else:
-            return (put_code, orcid, created)
+            return (put_code, orcid, created, visibility)
 
     def create_or_update_work(self, task_by_user, *args, **kwargs):
         """Create or update work record of a user."""
@@ -404,8 +405,9 @@ class MemberAPI(MemberAPIV20Api):
         if put_code:
             rec.put_code = wi.put_code
 
-        if wi.visibility:
-            rec.visibility = wi.visibility
+        visibility = wi.visibility
+        if visibility:
+            rec.visibility = visibility
 
         if wr.language_code:
             rec.language_code = wr.language_code
@@ -500,13 +502,13 @@ class MemberAPI(MemberAPIV20Api):
                 try:
                     orcid, put_code = location.split("/")[-3::2]
                     put_code = int(put_code)
-                    wi.put_code = put_code
-                    wi.save()
+                    visibility = None
                 except:
                     app.logger.exception("Failed to get ORCID iD/put-code from the response.")
                     raise Exception("Failed to get ORCID iD/put-code from the response.")
             elif resp.status == 200:
                 orcid = self.user.orcid
+                visibility = json.loads(resp.data).get("visibility") if hasattr(resp, "data") else None
 
         except ApiException as ex:
             if ex.status == 404:
@@ -518,7 +520,7 @@ class MemberAPI(MemberAPIV20Api):
         except:
             app.logger.exception(f"For {self.user} encountered exception")
         else:
-            return (put_code, orcid, created)
+            return (put_code, orcid, created, visibility)
 
     def create_or_update_funding(self, task_by_user, *args, **kwargs):
         """Create or update funding record of a user."""
@@ -1190,11 +1192,13 @@ class MemberAPI(MemberAPIV20Api):
                 try:
                     orcid, put_code = location.split("/")[-3::2]
                     put_code = int(put_code)
+                    visibility = None
                 except Exception:
                     app.logger.exception("Failed to get ORCID iD/put-code from the response.")
                     raise Exception("Failed to get ORCID iD/put-code from the response.")
             elif resp.status == 200:
                 orcid = self.user.orcid
+                visibility = json.loads(resp.data).get("visibility") if hasattr(resp, "data") else None
 
         except ApiException as apiex:
             app.logger.exception(f"For {self.user} encountered exception: {apiex}")
@@ -1203,7 +1207,7 @@ class MemberAPI(MemberAPIV20Api):
             app.logger.exception(f"For {self.user} encountered exception")
             raise ex
         else:
-            return (put_code, orcid, created)
+            return (put_code, orcid, created, visibility)
 
     def create_or_update_other_name(self, content=None, value=None, display_index=None, orcid=None, put_code=None,
                                     visibility=None, *args, **kwargs):
@@ -1233,11 +1237,13 @@ class MemberAPI(MemberAPIV20Api):
                 try:
                     orcid, put_code = location.split("/")[-3::2]
                     put_code = int(put_code)
+                    visibility = None
                 except Exception:
                     app.logger.exception("Failed to get ORCID iD/put-code from the response.")
                     raise Exception("Failed to get ORCID iD/put-code from the response.")
             elif resp.status == 200:
                 orcid = self.user.orcid
+                visibility = json.loads(resp.data).get("visibility") if hasattr(resp, "data") else None
 
         except ApiException as apiex:
             app.logger.exception(f"For {self.user} encountered exception: {apiex}")
@@ -1246,7 +1252,7 @@ class MemberAPI(MemberAPIV20Api):
             app.logger.exception(f"For {self.user} encountered exception")
             raise ex
         else:
-            return (put_code, orcid, created)
+            return (put_code, orcid, created, visibility)
 
     def create_or_update_address(self, country=None, value=None, display_index=None, orcid=None, put_code=None,
                                  visibility=None, *args, **kwargs):
@@ -1276,11 +1282,13 @@ class MemberAPI(MemberAPIV20Api):
                 try:
                     orcid, put_code = location.split("/")[-3::2]
                     put_code = int(put_code)
+                    visibility = None
                 except Exception:
                     app.logger.exception("Failed to get ORCID iD/put-code from the response.")
                     raise Exception("Failed to get ORCID iD/put-code from the response.")
             elif resp.status == 200:
                 orcid = self.user.orcid
+                visibility = json.loads(resp.data).get("visibility") if hasattr(resp, "data") else None
 
         except ApiException as apiex:
             app.logger.exception(f"For {self.user} encountered exception: {apiex}")
@@ -1289,7 +1297,7 @@ class MemberAPI(MemberAPIV20Api):
             app.logger.exception(f"For {self.user} encountered exception")
             raise ex
         else:
-            return (put_code, orcid, created)
+            return (put_code, orcid, created, visibility)
 
     def create_or_update_person_external_id(self, type=None, value=None, url=None, relationship=None,
                                             display_index=None, orcid=None, put_code=None, visibility=None,
@@ -1325,11 +1333,13 @@ class MemberAPI(MemberAPIV20Api):
                 try:
                     orcid, put_code = location.split("/")[-3::2]
                     put_code = int(put_code)
+                    visibility = None
                 except Exception:
                     app.logger.exception("Failed to get ORCID iD/put-code from the response.")
                     raise Exception("Failed to get ORCID iD/put-code from the response.")
             elif resp.status == 200:
                 orcid = self.user.orcid
+                visibility = json.loads(resp.data).get("visibility") if hasattr(resp, "data") else None
 
         except ApiException as apiex:
             app.logger.exception(f"For {self.user} encountered exception: {apiex}")
@@ -1338,7 +1348,7 @@ class MemberAPI(MemberAPIV20Api):
             app.logger.exception(f"For {self.user} encountered exception")
             raise ex
         else:
-            return (put_code, orcid, created)
+            return (put_code, orcid, created, visibility)
 
     def create_or_update_keyword(self, content=None, value=None, display_index=None, orcid=None, put_code=None,
                                  visibility=None, *args, **kwargs):
@@ -1369,11 +1379,13 @@ class MemberAPI(MemberAPIV20Api):
                 try:
                     orcid, put_code = location.split("/")[-3::2]
                     put_code = int(put_code)
+                    visibility = None
                 except Exception:
                     app.logger.exception("Failed to get ORCID iD/put-code from the response.")
                     raise Exception("Failed to get ORCID iD/put-code from the response.")
             elif resp.status == 200:
                 orcid = self.user.orcid
+                visibility = json.loads(resp.data).get("visibility") if hasattr(resp, "data") else None
 
         except ApiException as apiex:
             app.logger.exception(f"For {self.user} encountered exception: {apiex}")
@@ -1382,7 +1394,7 @@ class MemberAPI(MemberAPIV20Api):
             app.logger.exception(f"For {self.user} encountered exception")
             raise ex
         else:
-            return (put_code, orcid, created)
+            return (put_code, orcid, created, visibility)
 
     def get_webhook_access_token(self):
         """Retrieve the ORCID webhook access tonke and store it."""

--- a/orcid_hub/orcid_client.py
+++ b/orcid_hub/orcid_client.py
@@ -579,9 +579,10 @@ class MemberAPI(MemberAPIV20Api):
         rec.title = FundingTitle(title=title, translated_title=translated_title)  # noqa: F405
         rec.short_description = short_description
         rec.amount = Amount(value=amount, currency_code=currency_code)  # noqa: F405
+        visibility = fi.visibility
 
-        if fi.visibility:
-            rec.visibility = fi.visibility
+        if visibility:
+            rec.visibility = visibility
 
         if put_code:
             rec.put_code = put_code
@@ -671,13 +672,13 @@ class MemberAPI(MemberAPIV20Api):
                 try:
                     orcid, put_code = location.split("/")[-3::2]
                     put_code = int(put_code)
-                    fi.put_code = put_code
-                    fi.save()
+                    visibility = None
                 except:
                     app.logger.exception("Failed to get ORCID iD/put-code from the response.")
                     raise Exception("Failed to get ORCID iD/put-code from the response.")
             elif resp.status == 200:
                 orcid = self.user.orcid
+                visibility = json.loads(resp.data).get("visibility") if hasattr(resp, "data") else None
 
         except ApiException as ex:
             if ex.status == 404:
@@ -689,7 +690,7 @@ class MemberAPI(MemberAPIV20Api):
         except:
             app.logger.exception(f"For {self.user} encountered exception")
         else:
-            return (put_code, orcid, created)
+            return (put_code, orcid, created, visibility)
 
     def create_or_update_individual_funding(self, funding_title=None, funding_translated_title=None,
                                             translated_title_language=None, funding_type=None, funding_subtype=None,

--- a/orcid_hub/utils.py
+++ b/orcid_hub/utils.py
@@ -609,13 +609,15 @@ def create_or_update_funding(user, org_id, records, *args, **kwargs):
             fi = task_by_user.record.invitee
 
             try:
-                put_code, orcid, created = api.create_or_update_funding(task_by_user)
+                put_code, orcid, created, visibility = api.create_or_update_funding(task_by_user)
                 if created:
                     fi.add_status_line(f"Funding record was created.")
                 else:
                     fi.add_status_line(f"Funding record was updated.")
                 fi.orcid = orcid
                 fi.put_code = put_code
+                if fi.visibility != visibility:
+                    fi.visibility = visibility
 
             except Exception as ex:
                 logger.exception(f"For {user} encountered exception")

--- a/orcid_hub/utils.py
+++ b/orcid_hub/utils.py
@@ -439,13 +439,15 @@ def create_or_update_work(user, org_id, records, *args, **kwargs):
             wi = task_by_user.record.invitee
 
             try:
-                put_code, orcid, created = api.create_or_update_work(task_by_user)
+                put_code, orcid, created, visibility = api.create_or_update_work(task_by_user)
                 if created:
                     wi.add_status_line(f"Work record was created.")
                 else:
                     wi.add_status_line(f"Work record was updated.")
                 wi.orcid = orcid
                 wi.put_code = put_code
+                if wi.visibility != visibility:
+                    wi.visibility = visibility
 
             except Exception as ex:
                 logger.exception(f"For {user} encountered exception")
@@ -527,13 +529,15 @@ def create_or_update_peer_review(user, org_id, records, *args, **kwargs):
             pi = pr.invitee
 
             try:
-                put_code, orcid, created = api.create_or_update_peer_review(task_by_user)
+                put_code, orcid, created, visibility = api.create_or_update_peer_review(task_by_user)
                 if created:
                     pi.add_status_line(f"Peer review record was created.")
                 else:
                     pi.add_status_line(f"Peer review record was updated.")
                 pi.orcid = orcid
                 pi.put_code = put_code
+                if pi.visibility != visibility:
+                    pi.visibility = visibility
 
             except Exception as ex:
                 logger.exception(f"For {user} encountered exception")
@@ -863,13 +867,13 @@ def create_or_update_properties(user, org_id, records, *args, **kwargs):
                     rr.add_status_line("Researcher property record unchanged.")
                 else:
                     if rr.type == "URL":
-                        put_code, orcid, created = api.create_or_update_researcher_url(**rr._data)
+                        put_code, orcid, created, visibility = api.create_or_update_researcher_url(**rr._data)
                     elif rr.type == "NAME":
-                        put_code, orcid, created = api.create_or_update_other_name(**rr._data)
+                        put_code, orcid, created, visibility = api.create_or_update_other_name(**rr._data)
                     elif rr.type == "COUNTRY":
-                        put_code, orcid, created = api.create_or_update_address(**rr._data)
+                        put_code, orcid, created, visibility = api.create_or_update_address(**rr._data)
                     else:
-                        put_code, orcid, created = api.create_or_update_keyword(**rr._data)
+                        put_code, orcid, created, visibility = api.create_or_update_keyword(**rr._data)
 
                     if created:
                         rr.add_status_line("Researcher property record was created.")
@@ -877,6 +881,8 @@ def create_or_update_properties(user, org_id, records, *args, **kwargs):
                         rr.add_status_line("Researcher property record was updated.")
                     rr.orcid = orcid
                     rr.put_code = put_code
+                    if rr.visibility != visibility:
+                        rr.visibility = visibility
             except ApiException as ex:
                 if ex.status == 404:
                     rr.put_code = None
@@ -963,13 +969,15 @@ def create_or_update_other_id(user, org_id, records, *args, **kwargs):
                 if no_orcid_call:
                     rr.add_status_line("Other ID record unchanged.")
                 else:
-                    put_code, orcid, created = api.create_or_update_person_external_id(**rr._data)
+                    put_code, orcid, created, visibility = api.create_or_update_person_external_id(**rr._data)
                     if created:
                         rr.add_status_line("Other ID record was created.")
                     else:
                         rr.add_status_line("Other ID record was updated.")
                     rr.orcid = orcid
                     rr.put_code = put_code
+                    if rr.visibility != visibility:
+                        rr.visibility = visibility
             except ApiException as ex:
                 if ex.status == 404:
                     rr.put_code = None

--- a/orcid_hub/utils.py
+++ b/orcid_hub/utils.py
@@ -1121,7 +1121,7 @@ def create_or_update_affiliations(user, org_id, records, *args, **kwargs):
                 if no_orcid_call:
                     ar.add_status_line(f"{str(affiliation)} record unchanged.")
                 else:
-                    put_code, orcid, created = api.create_or_update_affiliation(
+                    put_code, orcid, created, visibility = api.create_or_update_affiliation(
                         affiliation=affiliation, **ar._data)
                     if created:
                         ar.add_status_line(f"{str(affiliation)} record was created.")
@@ -1129,6 +1129,8 @@ def create_or_update_affiliations(user, org_id, records, *args, **kwargs):
                         ar.add_status_line(f"{str(affiliation)} record was updated.")
                     ar.orcid = orcid
                     ar.put_code = put_code
+                    if ar.visibility != visibility:
+                        ar.visibility = visibility
 
             except Exception as ex:
                 logger.exception(f"For {user} encountered exception")

--- a/orcid_hub/views.py
+++ b/orcid_hub/views.py
@@ -2329,27 +2329,27 @@ def edit_record(user_id, section_type, put_code=None):
                         **{f.name: f.data
                            for f in form})
             elif section_type == "RUR":
-                put_code, orcid, created = api.create_or_update_researcher_url(
+                put_code, orcid, created, visibility = api.create_or_update_researcher_url(
                     put_code=put_code,
                     **{f.name: f.data
                        for f in form})
             elif section_type == "ONR":
-                put_code, orcid, created = api.create_or_update_other_name(
+                put_code, orcid, created, visibility = api.create_or_update_other_name(
                     put_code=put_code,
                     **{f.name: f.data
                        for f in form})
             elif section_type == "ADR":
-                put_code, orcid, created = api.create_or_update_address(
+                put_code, orcid, created, visibility = api.create_or_update_address(
                     put_code=put_code,
                     **{f.name: f.data
                        for f in form})
             elif section_type == "EXR":
-                put_code, orcid, created = api.create_or_update_person_external_id(
+                put_code, orcid, created, visibility = api.create_or_update_person_external_id(
                     put_code=put_code,
                     **{f.name: f.data
                        for f in form})
             elif section_type == "KWR":
-                put_code, orcid, created = api.create_or_update_keyword(
+                put_code, orcid, created, visibility = api.create_or_update_keyword(
                     put_code=put_code,
                     **{f.name: f.data
                        for f in form})

--- a/orcid_hub/views.py
+++ b/orcid_hub/views.py
@@ -2354,7 +2354,7 @@ def edit_record(user_id, section_type, put_code=None):
                     **{f.name: f.data
                        for f in form})
             else:
-                put_code, orcid, created = api.create_or_update_affiliation(
+                put_code, orcid, created, visibility = api.create_or_update_affiliation(
                     put_code=put_code,
                     affiliation=Affiliation[section_type],
                     **{f.name: f.data

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -683,7 +683,7 @@ def test_create_or_update_property_record(app, mocker):
         email="test1234456@mailinator.com",
         visibility="PUBLIC",
         value="dummy name",
-        display_index=0)
+        display_index=1)
 
     PropertyRecord.create(
         task=t,
@@ -695,7 +695,7 @@ def test_create_or_update_property_record(app, mocker):
         email="test1234456@mailinator.com",
         visibility="PUBLIC",
         value="IN",
-        display_index=0)
+        display_index=1)
 
     PropertyRecord.create(
         task=t,
@@ -708,7 +708,7 @@ def test_create_or_update_property_record(app, mocker):
         visibility="PUBLIC",
         name="url name",
         value="https://www.xyz.com",
-        display_index=0)
+        display_index=1)
 
     PropertyRecord.create(
         task=t,
@@ -720,7 +720,7 @@ def test_create_or_update_property_record(app, mocker):
         email="test1234456@mailinator.com",
         visibility="PUBLIC",
         value="dummy name",
-        display_index=0)
+        display_index=1)
 
     UserInvitation.create(
         invitee=u,
@@ -775,7 +775,7 @@ def test_process_other_id_records(app, mocker):
         last_name="Test",
         email="test1234456@mailinator.com",
         visibility="PUBLIC",
-        display_index=0)
+        display_index=1)
 
     UserInvitation.create(
         invitee=u,
@@ -877,7 +877,8 @@ def test_create_or_update_affiliation(app, mocker):
         department="Test",
         city="Test",
         state="Test",
-        country="Test")
+        country="Test",
+        visibility="PUBLIC")
     AffiliationRecord.create(
         is_active=True,
         task=t,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1486,11 +1486,11 @@ Roshan,researcher.010@mailinator.com
             "save":
             "Upload",
             "file_": (
-                BytesIO(b"""First Name,Last Name,Email,Affiliation Type
-Roshan,Pawar,researcher.010@mailinator.com,Student
-Roshan,Pawar,researcher.010@mailinator.com,Staff
-Rad,Cirskis,researcher.990@mailinator.com,Staff
-Rad,Cirskis,researcher.990@mailinator.com,Student
+                BytesIO(b"""First Name,Last Name,Email,Affiliation Type, Visibility, Disambiguated Id, Disambiguation Source
+Roshan,Pawar,researcher.010@mailinator.com,Student,PRIVate,3232,RINGGOLD
+Roshan,Pawar,researcher.010@mailinator.com,Staff,PRIVate,3232,RINGGOLD
+Rad,Cirskis,researcher.990@mailinator.com,Staff,PRIVate,3232,RINGGOLD
+Rad,Cirskis,researcher.990@mailinator.com,Student,PRIVate,3232,RINGGOLD
 """),
                 "affiliations.csv",
             ),
@@ -2188,7 +2188,9 @@ def test_edit_record(request_ctx):
                     "org_name": "TEST",
                     "funding_title": "TEST",
                     "funding_type": "AWARD",
+                    "funding_translated_title": "HI",
                     "translated_title_language": "hi",
+                    "total_funding_amount": "1000",
                     "total_funding_amount_currency": "NZD",
                     "grant_type": "https://test.com",
                     "grant_url": "https://test.com",


### PR DESCRIPTION
These are the changes done related to the visibility of an item:

1) We have added visibility column in an affiliation record.
2) We are currently getting the actual visibility of the item in update ORCID call so we are updating our visibility column of the uploaded task based on the visibility returned.
3) However, when the record is created on ORCID, we are not currently getting the visibility from ORCID creation response. So we don't know whether the item visibility was overridden by users preference or not. 

For example:
if Admin tries to create an item with visibility "PUBLIC" and user has a preference "PRIVATE" then the item on ORCID will be created with visibility "PRIVATE" and there is no way to know about the item's actual current visibility through the creation response. 

This can lead to visibility error if the admin tries to do reset or update the item, So most suitable option here is to make visibility column of the uploaded task to empty as soon as the item is created and wait till ORCID starts returning actual visibility of the item in creation response.

DB Changes:
-------------------------------------------
alter table affiliation_record add column visibility varchar(100);