### PR TITLE
Orcidhub 475/476

### DIFF
--- a/orcid_hub/utils.py
+++ b/orcid_hub/utils.py
@@ -1133,10 +1133,10 @@ def process_work_records(max_rows=20, record_id=None):
             t.id,
             t.org_id,
             t.record.id,
-            t.record.invitee.user,)):
+            (lambda r: r.user if r.user.id else None)(t.record.invitee),)):
         # If we have the token associated to the user then update the work record,
         # otherwise send him an invite
-        if (user.id is None or user.orcid is None or not OrcidToken.select().where(
+        if (user is None or user.orcid is None or not OrcidToken.select().where(
             (OrcidToken.user_id == user.id) & (OrcidToken.org_id == org_id)
                 & (OrcidToken.scopes.contains("/activities/update"))).exists()):  # noqa: E127, E129
 
@@ -1259,9 +1259,9 @@ def process_peer_review_records(max_rows=20, record_id=None):
             t.id,
             t.org_id,
             t.record.id,
-            t.record.invitee.user,)):
+            (lambda r: r.user if r.user.id else None)(t.record.invitee),)):
         """If we have the token associated to the user then update the peer record, otherwise send him an invite"""
-        if (user.id is None or user.orcid is None or not OrcidToken.select().where(
+        if (user is None or user.orcid is None or not OrcidToken.select().where(
             (OrcidToken.user_id == user.id) & (OrcidToken.org_id == org_id)
                 & (OrcidToken.scopes.contains("/activities/update"))).exists()):  # noqa: E127, E129
 
@@ -1385,9 +1385,9 @@ def process_funding_records(max_rows=20, record_id=None):
             t.id,
             t.org_id,
             t.record.id,
-            t.record.invitee.user,)):
+            (lambda r: r.user if r.user.id else None)(t.record.invitee),)):
         """If we have the token associated to the user then update the funding record, otherwise send him an invite"""
-        if (user.id is None or user.orcid is None or not OrcidToken.select().where(
+        if (user is None or user.orcid is None or not OrcidToken.select().where(
             (OrcidToken.user_id == user.id) & (OrcidToken.org_id == org_id)
                 & (OrcidToken.scopes.contains("/activities/update"))).exists()):  # noqa: E127, E129
 
@@ -1508,8 +1508,8 @@ def process_affiliation_records(max_rows=20, record_id=None):
     for (task_id, org_id, user), tasks_by_user in groupby(tasks, lambda t: (
             t.id,
             t.org_id,
-            t.record.user, )):
-        if (user.id is None or user.orcid is None or not OrcidToken.select().where(
+            (lambda r: r.user if r.user.id else None)(t.record))):
+        if (user is None or user.orcid is None or not OrcidToken.select().where(
             (OrcidToken.user_id == user.id) & (OrcidToken.org_id == org_id)
                 & (OrcidToken.scopes.contains("/activities/update"))).exists()):  # noqa: E127, E129
             # maps invitation attributes to affiliation type set:
@@ -1621,18 +1621,17 @@ def process_property_records(max_rows=20, record_id=None):
             tasks = tasks.where(PropertyRecord.id.in_(record_id))
         else:
             tasks = tasks.where(PropertyRecord.id == record_id)
-
     for (task_id, org_id, user), tasks_by_user in groupby(tasks, lambda t: (
             t.id,
             t.org_id,
-            t.record.user, )):
-        if (not user.id or not user.orcid or not OrcidToken.select().where(
+            (lambda r: r.user if r.user.id else None)(t.record),)):
+        if (not user or not user.orcid or not OrcidToken.select().where(
                 OrcidToken.user_id == user.id, OrcidToken.org_id == org_id,
                 OrcidToken.scopes.contains("/person/update")).exists()):  # noqa: E127, E129
             for k, tasks in groupby(
                     tasks_by_user,
                     lambda t: (t.created_by, t.org, t.record.email, t.record.first_name,
-                               t.record.last_name, t.record.user)):  # noqa: E501
+                               t.record.last_name, user)):  # noqa: E501
                 try:
                     send_user_invitation(*k, task_id=task_id)
                     status = "The invitation sent at " + datetime.utcnow().isoformat(timespec="seconds")
@@ -1721,8 +1720,8 @@ def process_other_id_records(max_rows=20, record_id=None):
     for (task_id, org_id, user), tasks_by_user in groupby(tasks, lambda t: (
             t.id,
             t.org_id,
-            t.record.user, )):
-        if (user.id is None or user.orcid is None or not OrcidToken.select().where(
+            (lambda r: r.user if r.user.id else None)(t.record), )):
+        if (user is None or user.orcid is None or not OrcidToken.select().where(
             (OrcidToken.user_id == user.id) & (OrcidToken.org_id == org_id)
                 & (OrcidToken.scopes.contains("/person/update"))).exists()):  # noqa: E127, E129
             for k, tasks in groupby(
@@ -1731,7 +1730,7 @@ def process_other_id_records(max_rows=20, record_id=None):
                                t.record.last_name)):  # noqa: E501
                 try:
                     email = k[2]
-                    send_user_invitation(*k, task_id=task_id)
+                    send_user_invitation(*k, task_id=task_id, invitation_template="email/property_invitation.html")
                     status = "The invitation sent at " + datetime.utcnow().isoformat(timespec="seconds")
                     (OtherIdRecord.update(status=OtherIdRecord.status + "\n" + status).where(
                         OtherIdRecord.status.is_null(False), OtherIdRecord.email == email).execute())
@@ -1766,7 +1765,7 @@ def process_other_id_records(max_rows=20, record_id=None):
                     _external=True)
                 try:
                     send_email(
-                        "email/work_task_completed.html",
+                        "email/task_completed.html",
                         subject="Other ID Record Process Update",
                         recipient=(task.created_by.name, task.created_by.email),
                         error_count=error_count,

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -14,7 +14,6 @@ from orcid_hub.apis import yamlfy
 from orcid_hub.data_apis import plural
 from orcid_hub.models import (AffiliationRecord, AsyncOrcidResponse, Client, OrcidToken,
                               Organisation, Task, TaskType, Token, User, UserInvitation)
-
 from unittest.mock import patch, MagicMock
 from tests import utils
 
@@ -1528,7 +1527,7 @@ def test_property_api(client, mocker):
                        data=json.dumps(records))
     assert resp.status_code == 200
     assert Task.select().count() == 6
-    assert UserInvitation.select().count() == 10
+    assert UserInvitation.select().count() == 7
     get_profile.assert_called()
     send_email.assert_called()
     create_or_update_researcher_url.assert_called_once()


### PR DESCRIPTION
Changes to avoid sending multiple emails for a new user in a batch upload. 
Bug Cause: Due to new peewee update where groupby function was failing to check None reference.