### PR TITLE
Orcidhub 462/489

### DIFF
--- a/orcid_hub/__init__.py
+++ b/orcid_hub/__init__.py
@@ -135,6 +135,7 @@ class JSONEncoder(_JSONEncoder):
         return super().default(o)
 
 
+app.config["JSON_AS_ASCII"] = False
 app.json_encoder = JSONEncoder
 
 

--- a/orcid_hub/utils.py
+++ b/orcid_hub/utils.py
@@ -2513,7 +2513,7 @@ def dump_yaml(data):
     """Dump the objects into YAML representation."""
     yaml.add_representer(datetime, SafeRepresenterWithISODate.represent_datetime, Dumper=Dumper)
     yaml.add_representer(defaultdict, SafeRepresenter.represent_dict)
-    return yaml.dump(data)
+    return yaml.dump(data, allow_unicode=True)
 
 
 def enqueue_user_records(user):

--- a/orcid_hub/views.py
+++ b/orcid_hub/views.py
@@ -1114,8 +1114,13 @@ class CompositeRecordModelView(RecordModelView):
 
         try:
             try:
-                ds.yaml = yaml.safe_dump(json.loads(ds.json.replace("]\\", "]").replace("\\n", " ")))
-                response_data = ds.export(format=export_type)
+                if export_type == 'json':
+                    response_data = json.dumps(json.loads(ds.json), ensure_ascii=False)
+                elif export_type == 'yaml':
+                    response_data = yaml.safe_dump(json.loads(ds.json.replace("]\\", "]").replace("\\n", " ")),
+                                                   allow_unicode=True)
+                else:
+                    response_data = ds.export(format=export_type)
             except AttributeError:
                 response_data = getattr(ds, export_type)
         except (AttributeError, tablib.UnsupportedFormat):
@@ -1604,7 +1609,7 @@ class AffiliationRecordAdmin(CompositeRecordModelView):
         "start_date",
         "end_date",
         "city",
-        "state",
+        "region",
         "country",
         "disambiguated_id",
         "disambiguation_source",

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -301,7 +301,7 @@ def test_message_records(client, mocker):
                     # email="researcher@test0.edu",
                     first_name=i.first_name or "FN",
                     last_name=i.first_name or "LN",
-                    visibility=(i.visibility or "LIMITED").upper()))
+                    visibility=(i.visibility or "limited").lower()))
             invitee = Invitee.get(i.id)
             assert invitee.identifier == f"ID-{i.id}"
 
@@ -310,7 +310,7 @@ def test_message_records(client, mocker):
                            data=dict(email="a-new-one@org1234.edu",
                                      first_name="FN",
                                      last_name="LN",
-                                     visibility="LIMITED"))
+                                     visibility="limited"))
         assert r.invitees.count() == invitee_count + 1
 
     # Export and re-import


### PR DESCRIPTION
## Proposed change:

Now the yaml/json export should give correct encoding for strings like 'Wānanga' and 'Apārangi'

## fix for:
#787 