### PR TITLE
Quick fix for AffiliationRecord disambig id

### DIFF
--- a/orcid_hub/models.py
+++ b/orcid_hub/models.py
@@ -1453,7 +1453,7 @@ class AffiliationRecord(RecordModel):
     region = CharField(null=True, verbose_name="State/Region", max_length=100)
     country = CharField(null=True, max_length=2, choices=country_choices)
     disambiguated_id = CharField(
-        null=True, max_length=20, verbose_name="Disambiguated Organization Identifier")
+        null=True, verbose_name="Disambiguated Organization Identifier")
     disambiguation_source = CharField(
         null=True,
         max_length=100,


### PR DESCRIPTION
Change to https://github.com/Royal-Society-of-New-Zealand/NZ-ORCID-Hub/pull/729
was lost during a merge cycle, this is to put that expansion to character size back