### PR TITLE
Fix for #1270 (Do Not Merge)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME = orcidhub/app
-VERSION = 6.8
+VERSION = 6.9
 
 .PHONY: all build test tag
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -16,7 +16,7 @@ pep8-naming>=0.4.1
 pydocs>=0.2
 pydocstyle>=2.0.0,<4.0.0
 Pygments>=2.2.0
-pytest<3.7.0
+pytest<6.0.0
 pytest-cov>=2.5.1
 pytest-mock
 testpath>=0.3.1

--- a/orcid_hub/forms.py
+++ b/orcid_hub/forms.py
@@ -346,8 +346,8 @@ class ExternalIdentifierForm(CommonFieldsForm):
     type = SelectField(choices=EMPTY_CHOICES + models.external_id_type_choices, validators=[validators.required()],
                        description="External Identifier Type")
     value = StringField("External Identifier Value", [validators.required()])
-    url = StringField("External Identifier Url", [validators.required()])
-    relationship = SelectField(choices=models.relationship_choices, default="SELF",
+    url = StringField("External Identifier Url")
+    relationship = SelectField(choices=models.relationship_choices, default="self",
                                description="External Id Relationship")
 
 

--- a/orcid_hub/models.py
+++ b/orcid_hub/models.py
@@ -4284,8 +4284,8 @@ class OtherIdRecord(ExternalIdModel):
                     value = val(row, 2)
                     url = val(row, 3)
                     relationship = val(row, 4)
-                    if val(row, 4):
-                        relationship = val(row, 4).replace("_", "-").lower()
+                    if relationship:
+                        relationship = relationship.replace("_", "-").lower()
                     first_name = val(row, 6)
                     last_name = val(row, 7)
                     is_active = val(row, 11, "").lower() in ["y", "yes", "1", "true"]

--- a/orcid_hub/models.py
+++ b/orcid_hub/models.py
@@ -4283,7 +4283,9 @@ class OtherIdRecord(ExternalIdModel):
                     rec_type = val(row, 1, "").lower()
                     value = val(row, 2)
                     url = val(row, 3)
-                    relationship = val(row, 4, "").replace("_", "-").lower()
+                    relationship = val(row, 4)
+                    if val(row, 4):
+                        relationship = val(row, 4).replace("_", "-").lower()
                     first_name = val(row, 6)
                     last_name = val(row, 7)
                     is_active = val(row, 11, "").lower() in ["y", "yes", "1", "true"]
@@ -4299,12 +4301,6 @@ class OtherIdRecord(ExternalIdModel):
                     if not value:
                         raise ModelException(
                             f"Missing External Id Value: {value}, #{row_no+2}: {row}."
-                        )
-
-                    if not (url and relationship):
-                        raise ModelException(
-                            f"Missing External Id Url: {url} or External Id Relationship: {relationship} #{row_no+2}: "
-                            f"{row}."
                         )
 
                     visibility = val(row, 10)

--- a/pytest.sh
+++ b/pytest.sh
@@ -11,7 +11,7 @@ export ENV=test
 ##   flask process
 export DATABASE_URL="sqlite:///:memory:"
 export EXTERNAL_SP=''
-[ -z $RQ_REDIS_URL ] && RQ_REDIS_URL=redis://redis:6379/0
+# [ -z $RQ_REDIS_URL ] && RQ_REDIS_URL=redis://redis:6379/0
 export RQ_REDIS_URL
 export LOAD_TEST=1
 export RQ_ASYNC=0


### PR DESCRIPTION
I have done the changes as per https://github.com/Royal-Society-of-New-Zealand/NZ-ORCID-Hub/issues/1270

Removed url from compulsory fields both in file upload and on form, however if user doesn't specify `url` then ORCID call will still fail because of issue on ORCID side.
![image](https://user-images.githubusercontent.com/13748294/84653045-c54b7780-af60-11ea-9264-1c638330f65f.png)

Till the bug is fixed at ORCID end, the user will have to specify `url`
![image](https://user-images.githubusercontent.com/13748294/84653189-122f4e00-af61-11ea-99dc-58ecb193e14b.png)
