### PR TITLE
Allow setting of DKIM parameters

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -137,6 +137,8 @@ Variable                    Description
 MAIL_SERVER                 Mail server's name or IP (default: *dev.orcidhub.org.nz*)
 MAIL_PORT                   Port for sending mail (default: *25*)
 MAIL_DEFAULT_SENDER         Mail from Hub to be sent as (default *no-reply@orcidhub.org.nz*)
+MAIL_DKIM_DOMAIN            Domain name to use for DKIM signed mail (default *orcidhub.org.nz*)
+MAIL_DKIM_SELECTOR          Selector for DKIM signed mail (default *default*)
 RQ_REDIS_URL                Redis server for rq (default *redis://localhost:6379/0*)
 ==========================  ==================
 

--- a/orcid_hub/config.py
+++ b/orcid_hub/config.py
@@ -54,6 +54,8 @@ MAIL_PORT = int(getenv("MAIL_PORT", 25))
 MAIL_SUPPRESS_SEND = False
 MAIL_DEFAULT_SENDER = getenv("MAIL_DEFAULT_SENDER", "no-reply@orcidhub.org.nz")
 MAIL_SERVER = getenv("MAIL_SERVER", "gateway")
+MAIL_DKIM_DOMAIN = getenv("MAIL_DKIM_DOMAIN", "orcidhub.org.nz")
+MAIL_DKIM_SELECTOR = getenv("MAIL_DKIM_SELECTOR", "default")
 
 MEMBER_API_FORM_MAIL = bool(getenv("MEMBER_API_FORM_MAIL"))
 MEMBER_API_FORM_BASE_URL = "https://orcid.org/content/register-client-application-sandbox" \

--- a/orcid_hub/utils.py
+++ b/orcid_hub/utils.py
@@ -229,9 +229,11 @@ def send_email(
         text=plain_msg,
     )
     dkim_key_path = app.config.get("DKIM_KEY_PATH")
+    dkim_domain = app.config.get("MAIL_DKIM_DOMAIN")
+    dkim_selector = app.config.get("MAIL_DKIM_SELECTOR")
     if dkim_key_path and os.path.exists(dkim_key_path):
         with open(dkim_key_path) as key_file:
-            msg.dkim(key=key_file, domain="orcidhub.org.nz", selector="default")
+            msg.dkim(key=key_file, domain=dkim_domain, selector=dkim_selector)
     elif dkim_key_path:
         raise Exception(f"Cannot find DKIM key file: {dkim_key_path}!")
     if cc_email:


### PR DESCRIPTION
At the moment the DKIM domain and selector are hardcoded into the application.

This makes them a configuration option, whilst still preserving the existing hardcoded values as the defaults.