### PR TITLE
Remove hardcoded URLs from referer checks

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -148,6 +148,7 @@ Variable                    Description
 SECRET_KEY                  To specify the Hub secret key for data encryption (optional)
 SENTRY_DSN                  Sentry project DSN (optional)
 GA_TRACKING_ID              Google Analytics Tracking ID (optional)
+CSRF_DOMAINS                Semicolon delimited whitelist of FQDNs, used to check Referer headers (default *localhost;c9users.io*)
 ==========================  ==================
 
 Minimal deployment via PyPI

--- a/orcid_hub/config.py
+++ b/orcid_hub/config.py
@@ -64,6 +64,7 @@ CRED_TYPE_PREMIUM = 2
 APP_NAME = 'NZ ORCID HUB'
 APP_DESCRIPTION = 'This is an ORCID integration through the NZ ORCID HUB connecting'
 APP_URL = "https://" + (ENV + ".orcidhub.org.nz" if ENV != "prod" else "orcidhub.org.nz")
+CSRF_DOMAINS = getenv("CSRF_DOMAINS", "localhost;c9users.io").split(";")
 SEED_HUB_ADMIN = getenv("SEED_HUB_ADMIN", "rad42@mailinator.com")
 
 # External Shibboleth SP login URL (e.g., https://test.orcidhub.org.nz/Tuakiri/login)

--- a/orcid_hub/utils.py
+++ b/orcid_hub/utils.py
@@ -90,14 +90,18 @@ def get_next_url(endpoint=None):
     if not _next and endpoint:
         _next = url_for(endpoint)
 
-    if _next and (
-        "orcidhub.org.nz" in _next
-        or _next.startswith("/")
-        or "127.0" in _next
-        or "localhost" in _next
-        or "c9users.io" in _next
-    ):
-        return _next
+    if _next:
+        if _next.startswith("/"):
+            return _next
+        try:
+            csrf = urlparse(_next).netloc
+            if (csrf == urlparse(app.config.get("APP_URL")).netloc
+                or csrf.startswith("127.0.")
+                or csrf in app.config.get("CSRF_DOMAINS")
+            ):
+                return _next
+        except:
+            pass
 
     try:
         if Delegate.select().where(Delegate.hostname ** f"%{urlparse(_next).netloc}%").exists():


### PR DESCRIPTION
At the moment the get_next_url() contains domains that are hardcoded into the application. In addition, because it uses `in`, it is possible to subvert the checks using a carefully crafted URL.

This patch makes the domains that are accepted as referers a configuration option, whilst still preserving the existing hardcoded values as the defaults. However, it does introduce a change in behaviour in that only the host portion of a URL is compared against the domains (rather than any substring).

The new `CSRF_DOMAINS` option is semicolon-delimited, in part because that allows it to be set from the environment. However, ultimately it needs to be a list.

The check for `127.0.` remains hardcoded because it's not safe to include a partial in `CSRF_DOMAINS`. However, the check is now whether the host portion of a URL starts with those, which should be safe.