### PR TITLE
Replace hardcoded support address with config variable

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -137,6 +137,7 @@ Variable                    Description
 MAIL_SERVER                 Mail server's name or IP (default: *dev.orcidhub.org.nz*)
 MAIL_PORT                   Port for sending mail (default: *25*)
 MAIL_DEFAULT_SENDER         Mail from Hub to be sent as (default *no-reply@orcidhub.org.nz*)
+MAIL_SUPPORT_ADDRESS        Helpdesk email address, used in errors and as default Reply-To (default *orcid@royalsociety.org.nz*)
 RQ_REDIS_URL                Redis server for rq (default *redis://localhost:6379/0*)
 ==========================  ==================
 

--- a/docs/sendmail.rst
+++ b/docs/sendmail.rst
@@ -15,7 +15,7 @@ Sendmail configuration for source or PyPI
 
 On the basis that your environment is able to send email with an address (and from
 an IP) that is allowed by your domain, your hub instance email is enabled by setting
-the following variables: MAIL_SERVER; MAIL_PORT; and MAIL_DEFAULT_SENDER.
+the following variables: MAIL_SERVER; MAIL_PORT; MAIL_DEFAULT_SENDER; and MAIL_DEFAULT_SENDER.
 
 NB: To ensure delivery and avoid appearing spammy, we have both SPF and DKIM enabled
 for our dev, UAT, and production environments.

--- a/orcid_hub/authcontroller.py
+++ b/orcid_hub/authcontroller.py
@@ -54,6 +54,7 @@ from .config import (
     ORCID_API_BASE,
     ORCID_BASE_URL,
     TOKEN_URL,
+    MAIL_SUPPORT_ADDRESS,
 )
 from .forms import OrgConfirmationForm, TestDataForm
 from .login_provider import roles_required
@@ -729,7 +730,7 @@ def orcid_callback():
         if state != session.get("oauth_state"):
             flash(
                 "Retry giving permissions, or if the issue persists "
-                "please contact orcid@royalsociety.org.nz for support",
+                f"please contact {MAIL_SUPPORT_ADDRESS} for support",
                 "danger",
             )
             app.logger.error(
@@ -1280,7 +1281,7 @@ def orcid_login(invitation_token=None):
 
     except Exception as ex:
         flash(
-            "Something went wrong. Please contact orcid@royalsociety.org.nz for support!", "danger"
+            f"Something went wrong. Please contact {MAIL_SUPPORT_ADDRESS} for support!", "danger"
         )
         app.logger.exception(f"Failed to login via ORCID: {ex}")
         return redirect(url_for("index"))
@@ -1295,7 +1296,7 @@ def orcid_login_callback(request):
     if not state or state != session.get("oauth_state"):
         flash(
             "Something went wrong, Please retry giving permissions or if issue persists then, "
-            "Please contact orcid@royalsociety.org.nz for support",
+            f"Please contact {MAIL_SUPPORT_ADDRESS} for support",
             "danger",
         )
         return redirect(url_for("index"))
@@ -1375,7 +1376,7 @@ def orcid_login_callback(request):
                     flash(
                         f"This {orcid_id} is already associated with other email address of same organisation: {org}. "
                         "Please use other ORCID iD to login. If you need help then "
-                        "kindly contact orcid@royalsociety.org.nz support for issue",
+                        f"kindly contact {MAIL_SUPPORT_ADDRESS} support for issue",
                         "danger",
                     )
                     logout_user()
@@ -1401,7 +1402,7 @@ def orcid_login_callback(request):
             flash(
                 f"This {email} is already associated with {user.orcid} and you are trying to login with {orcid_id}. "
                 "Please use correct ORCID iD to login. If you need help then "
-                "kindly contact orcid@royalsociety.org.nz support for issue",
+                f"kindly contact {MAIL_SUPPORT_ADDRESS} support for issue",
                 "danger",
             )
             logout_user()
@@ -1562,7 +1563,7 @@ def orcid_login_callback(request):
         return redirect(url_for("index"))
     except Exception as ex:
         flash(
-            f"Something went wrong contact orcid@royalsociety.org.nz support for issue: {ex}",
+            f"Something went wrong contact {MAIL_SUPPORT_ADDRESS} support for issue: {ex}",
             "danger",
         )
         app.logger.exception("Unhandled excetion occrured while handling ORCID call-back.")

--- a/orcid_hub/config.py
+++ b/orcid_hub/config.py
@@ -53,6 +53,7 @@ OAUTH2_PROVIDER_TOKEN_EXPIRES_IN = 86400  # Default Bearer token expires time, d
 MAIL_PORT = int(getenv("MAIL_PORT", 25))
 MAIL_SUPPRESS_SEND = False
 MAIL_DEFAULT_SENDER = getenv("MAIL_DEFAULT_SENDER", "no-reply@orcidhub.org.nz")
+MAIL_SUPPORT_ADDRESS = getenv("MAIL_SUPPORT_ADDRESS", "orcid@royalsociety.org.nz")
 MAIL_SERVER = getenv("MAIL_SERVER", "gateway")
 
 MEMBER_API_FORM_MAIL = bool(getenv("MEMBER_API_FORM_MAIL"))

--- a/orcid_hub/utils.py
+++ b/orcid_hub/utils.py
@@ -132,7 +132,7 @@ def send_email(
     recipient,
     cc_email=None,
     sender=(app.config.get("APP_NAME"), app.config.get("MAIL_DEFAULT_SENDER")),
-    reply_to=None,
+    reply_to=app.config.get("MAIL_SUPPORT_ADDRESS"),
     subject=None,
     base=None,
     logo=None,

--- a/orcid_hub/views.py
+++ b/orcid_hub/views.py
@@ -64,6 +64,7 @@ from .utils import get_next_url, read_uploaded_file, send_user_invitation
 
 HEADERS = {"Accept": "application/vnd.orcid+json", "Content-type": "application/vnd.orcid+json"}
 ORCID_BASE_URL = app.config["ORCID_BASE_URL"]
+MAIL_SUPPORT_ADDRESS = app.config["MAIL_SUPPORT_ADDRESS"]
 
 
 @app.errorhandler(401)
@@ -1857,7 +1858,7 @@ class ViewMembersAdmin(AppModelView):
                                   UserOrg.is_admin).exists():
             flash(
                 f"Failed to delete record for {model}, As User appears to be one of the admins. "
-                f"Please contact orcid@royalsociety.org.nz for support", "danger")
+                f"Please contact {MAIL_SUPPORT_ADDRESS} for support", "danger")
             return False
 
         for token in OrcidToken.select().where(OrcidToken.org == org, OrcidToken.user == model):
@@ -2045,7 +2046,7 @@ class GroupIdRecordAdmin(AppModelView):
                         orcid_token = utils.get_client_credentials_token(org=org, scopes="/group-id-record/update")
                     except Exception as ex:
                         flash("Something went wrong in ORCID call, "
-                              "please contact orcid@royalsociety.org.nz for support", "warning")
+                              f"please contact {MAIL_SUPPORT_ADDRESS} for support", "warning")
                         app.logger.exception(f'Exception occured {ex}')
 
                     api = orcid_client.MemberAPIV3(org=org, access_token=orcid_token.access_token)
@@ -2069,12 +2070,12 @@ class GroupIdRecordAdmin(AppModelView):
                         orcid_token.delete_instance()
                     flash("Something went wrong in ORCID call, Please try again by making by making necessary changes, "
                           "In case you understand the 'user-message' present in the status field or else "
-                          "please contact orcid@royalsociety.org.nz for support", "warning")
+                          f"please contact {MAIL_SUPPORT_ADDRESS} for support", "warning")
                     app.logger.exception(f'Exception occured {ex}')
                     gid.add_status_line(f"ApiException: {ex}")
                 except Exception as ex:
                     flash("Something went wrong in ORCID call, "
-                          "Please contact orcid@royalsociety.org.nz for support", "warning")
+                          f"Please contact {MAIL_SUPPORT_ADDRESS} for support", "warning")
                     app.logger.exception(f'Exception occured {ex}')
                     gid.add_status_line(f"Exception: {ex}")
                 finally:
@@ -2932,7 +2933,7 @@ def search_group_id_record():
                 orcid_token = utils.get_client_credentials_token(org=org, scopes="/group-id-record/read")
             except Exception as ex:
                 flash("Something went wrong in ORCID call, "
-                      "please contact orcid@royalsociety.org.nz for support", "warning")
+                      f"please contact {MAIL_SUPPORT_ADDRESS} for support", "warning")
                 app.logger.exception(f'Exception occured {ex}')
 
             api = orcid_client.MemberAPIV3(org=org, access_token=orcid_token.access_token)
@@ -2952,7 +2953,7 @@ def search_group_id_record():
             else:
                 flash(f"Something went wrong in ORCID call, Please try again by making necessary changes, "
                       f"In case you understand this message: {ex} or"
-                      f" else please contact orcid@royalsociety.org.nz for support", "warning")
+                      f" else please contact {MAIL_SUPPORT_ADDRESS} for support", "warning")
                 app.logger.warning(f'Exception occured {ex}')
 
         except Exception as ex:
@@ -3823,7 +3824,7 @@ def remove_linkage():
     if UserOrg.select().where(
                 (UserOrg.user_id == current_user.id) & (UserOrg.org_id == org.id) & UserOrg.is_admin).exists():
         flash(f"Failed to remove linkage for {current_user}, as this user appears to be one of the admins for {org}. "
-              "Please contact orcid@royalsociety.org.nz for support", "danger")
+              f"Please contact {MAIL_SUPPORT_ADDRESS} for support", "danger")
         return redirect(_url)
 
     for token in OrcidToken.select().where(OrcidToken.org_id == org.id, OrcidToken.user_id == current_user.id):


### PR DESCRIPTION
At the moment the `orcid@royalsociety.org.nz` email address is hardcoded into a number of error messages within the application.

This makes a new `MAIL_SUPPORT_ADDRESS` config option that allows the address to be set, whilst still preserving the existing hardcoded values as the defaults.

It also prefers to use the new `MAIL_SUPPORT_ADDRESS` as a default reply_to address rather than `MAIL_DEFAULT_SENDER` so that users replying to an email can reach somewhere sensible while bounces still go to a no-reply address.