### PR TITLE
Add headers to supress automatic responses to email

### DIFF
--- a/orcid_hub/utils.py
+++ b/orcid_hub/utils.py
@@ -239,6 +239,7 @@ def send_email(
     msg.set_headers({"reply-to": reply_to})
     msg.mail_to.append(recipient)
     msg.set_headers({"x-auto-response-suppress": "DR, RN, NRN, OOF"})
+    msg.set_headers({"auto-submitted": "auto-generated"})
     # Unsubscribe link:
     token = new_invitation_token(length=10)
     unsubscribe_url = url_for("unsubscribe", token=token, _external=True)

--- a/orcid_hub/utils.py
+++ b/orcid_hub/utils.py
@@ -238,6 +238,7 @@ def send_email(
         msg.cc.append(cc_email)
     msg.set_headers({"reply-to": reply_to})
     msg.mail_to.append(recipient)
+    msg.set_headers({"x-auto-response-suppress": "DR, RN, NRN, OOF"})
     # Unsubscribe link:
     token = new_invitation_token(length=10)
     unsubscribe_url = url_for("unsubscribe", token=token, _external=True)


### PR DESCRIPTION
This adds an X-Auto-Response-Suppress header to outbound mail in accordance with https://docs.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcmail/ced68690-498a-4567-9d14-5c01f974d8b1. In particular, this suppresses delivery notifications and out-of-office messages from compatible exchange servers

It also adds an RFC3834 Auto-Submitted header to indicate mail was automatically generated. This will suppress vacation responders in other MUAs.