### PR TITLE
Make it possible to override the SAML attribute map

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -129,6 +129,20 @@ ORCID_CLIENT_ID             Orcid API client ID and secret, e.g., *0000-1234-292
 ORCID_CLIENT_SECRET         Orcid API client ID and secret, e.g., *b25ab710-89b1-49e8-65f4-8df4f038dce9*
 ==========================  ==================
 
+Configuring the attribute mapping for EXTERNAL_SP. These should match the attributes exposed by your service provider (e.g. Shibboleth):
+
+==========================  ==================
+Variable                    Description
+==========================  ==================
+EXTERNAL_SP_ATTR_EPPN         Attribute name for "eduPersonPrincipalName" (default *Eppn*)
+EXTERNAL_SP_ATTR_SN           Attribute name for "sn" (default *Sn*)
+EXTERNAL_SP_ATTR_GIVENNAME    Attribute name for "givenName" (default *Givenname*)
+EXTERNAL_SP_ATTR_MAIL         Attribute name for "mail" (default *Mail*)
+EXTERNAL_SP_ATTR_DISPLAYNAME  Attribute name for "displayName" (default *Displayname*)
+EXTERNAL_SP_ATTR_ORG          Attribute name for organisation name (default *O*)
+EXTERNAL_SP_ATTR_AFFILIATION  Attribute name for "eduPersonAffiliation" (default *Unscoped-Affiliation*)
+EXTERNAL_SP_ATTR_ORCID        Attribute name for "eduPersonOrcid" hint (default *Orcid-Id*)
+
 Configuring mail and redis defaults
 
 ==========================  ==================

--- a/orcid_hub/authcontroller.py
+++ b/orcid_hub/authcontroller.py
@@ -276,30 +276,30 @@ def handle_login():
         data = request.headers
 
     try:
-        last_name = data["Sn"].encode("latin-1").decode("utf-8")
-        first_name = data["Givenname"].encode("latin-1").decode("utf-8")
+        last_name = data[app.config.get("EXTERNAL_SP_ATTR_SN")].encode("latin-1").decode("utf-8")
+        first_name = data[app.config.get("EXTERNAL_SP_ATTR_GIVENNAME")].encode("latin-1").decode("utf-8")
         email, *secondary_emails = re.split(
-            "[,; \t]", data["Mail"].encode("latin-1").decode("utf-8").lower()
+            "[,; \t]", data[app.config.get("EXTERNAL_SP_ATTR_MAIL")].encode("latin-1").decode("utf-8").lower()
         )
-        session["shib_O"] = shib_org_name = data["O"].encode("latin-1").decode("utf-8")
-        name = data.get("Displayname").encode("latin-1").decode("utf-8")
-        eppn = data.get("Eppn").encode("latin-1").decode("utf-8") or None
+        session["shib_O"] = shib_org_name = data[app.config.get("EXTERNAL_SP_ATTR_ORG")].encode("latin-1").decode("utf-8")
+        name = data.get(app.config.get("EXTERNAL_SP_ATTR_DISPLAYNAME")).encode("latin-1").decode("utf-8")
+        eppn = data.get(app.config.get("EXTERNAL_SP_ATTR_EPPN")).encode("latin-1").decode("utf-8") or None
         unscoped_affiliation = set(
             a.strip()
-            for a in data.get("Unscoped-Affiliation", "")
+            for a in data.get(app.config.get("EXTERNAL_SP_ATTR_AFFILIATION"), "")
             .encode("latin-1")
             .decode("utf-8")
             .replace(",", ";")
             .split(";")
         )
 
-        orcid = data.get("Orcid-Id")
+        orcid = data.get(app.config.get("EXTERNAL_SP_ATTR_ORCID"))
         if orcid:
             orcid = orcid.split("/")[-1]
             try:
                 validate_orcid_id(orcid)
             except ValueError:
-                app.logger.exception(f"Invalid OCID iD value recieved via 'Orcid-Id': {orcid}")
+                app.logger.exception(f"Invalid ORCID iD value recieved from external SP: {orcid}")
                 orcid = None
 
         app.logger.info(

--- a/orcid_hub/config.py
+++ b/orcid_hub/config.py
@@ -68,6 +68,15 @@ SEED_HUB_ADMIN = getenv("SEED_HUB_ADMIN", "rad42@mailinator.com")
 
 # External Shibboleth SP login URL (e.g., https://test.orcidhub.org.nz/Tuakiri/login)
 EXTERNAL_SP = getenv("EXTERNAL_SP") if ENV != "prod" else None
+# Attribute map for external SP
+EXTERNAL_SP_ATTR_EPPN = getenv("EXTERNAL_SP_ATTR_EPPN", "Eppn")
+EXTERNAL_SP_ATTR_SN = getenv("EXTERNAL_SP_ATTR_SN", "Sn")
+EXTERNAL_SP_ATTR_GIVENNAME = getenv("EXTERNAL_SP_ATTR_GIVENNAME", "Givenname")
+EXTERNAL_SP_ATTR_MAIL = getenv("EXTERNAL_SP_ATTR_MAIL", "Mail")
+EXTERNAL_SP_ATTR_DISPLAYNAME = getenv("EXTERNAL_SP_ATTR_DISPLAYNAME", "Displayname")
+EXTERNAL_SP_ATTR_ORG = getenv("EXTERNAL_SP_ATTR_ORG", "O")
+EXTERNAL_SP_ATTR_AFFILIATION = getenv("EXTERNAL_SP_ATTR_AFFILIATION", "Unscoped-Affiliation")
+EXTERNAL_SP_ATTR_ORCID = getenv("EXTERNAL_SP_ATTR_ORCID", "Orcid-Id")
 
 DEFAULT_COUNTRY = "NZ"
 


### PR DESCRIPTION
At the moment the SAML attribute map is hardcoded with Tuakiri-specific attribute names. While it is possible to match these by updating a shibboleth attribute-map.xml, it may be easier for other people to use names they're familiar with or that match their stock configs.

This change makes it possible to override the SAML attribute mapping from within the config, while preserving the existing hard coded values as defaults.