### PR TITLE
Jg expanding id relationship options

### DIFF
--- a/orcid_api_v3/models/external_idv30.py
+++ b/orcid_api_v3/models/external_idv30.py
@@ -196,7 +196,7 @@ class ExternalIDV30(object):
         :param external_id_relationship: The external_id_relationship of this ExternalIDV30.  # noqa: E501
         :type: str
         """
-        allowed_values = ["PART_OF", "SELF", "VERSION_OF", "part-of", "self", ]  # noqa: E501
+        allowed_values = ["PART_OF", "SELF", "VERSION_OF", "FUNDED_BY", "part-of", "self", "version-of", "funded-by"]  # noqa: E501
         if external_id_relationship not in allowed_values:
             raise ValueError(
                 "Invalid value for `external_id_relationship` ({0}), must be one of {1}"  # noqa: E501

--- a/orcid_hub/models.py
+++ b/orcid_hub/models.py
@@ -155,7 +155,7 @@ SUBJECT_TYPES = [
 REVIEWER_ROLES = ["chair", "editor", "member", "organizer", "reviewer"]
 REVIEW_TYPES = ["evaluation", "review"]
 review_type_choices = [(v, v.title()) for v in REVIEW_TYPES]
-RELATIONSHIPS = ["part-of", "self"]
+RELATIONSHIPS = ["part-of", "self", "version-of", "funded-by"]
 
 WORK_TYPES = [
     "artistic-performance",


### PR DESCRIPTION
Fixed "version-of" relationship type not properly reflected in swagger, 
and added new "funded-by" relationship to validation and allowed.