### PR TITLE
Replace pronouns with gender neutral ones

### DIFF
--- a/orcid_hub/authcontroller.py
+++ b/orcid_hub/authcontroller.py
@@ -560,7 +560,7 @@ if app.config.get("LOAD_TEST"):
 @app.route("/link")
 @login_required
 def link():
-    """Link the user's account with ORCID (i.e. affiliates user with his/her org on ORCID)."""
+    """Link the user's account with ORCID (i.e. affiliates user with their org on ORCID)."""
     # TODO: handle organisation that are not on-boarded
     redirect_uri = url_for("orcid_callback", _external=True)
     external_sp = app.config.get("EXTERNAL_SP")
@@ -860,7 +860,7 @@ def profile():
         )
         if resp_person.status_code == 401:
             orcid_token.delete_instance()
-            app.logger.info("%r has removed his organisation from trusted list", user)
+            app.logger.info("%r has removed their organisation from trusted list", user)
             return redirect(url_for("link"))
         else:
             users = User.select().where(User.orcid == user.orcid)

--- a/orcid_hub/utils.py
+++ b/orcid_hub/utils.py
@@ -2953,7 +2953,7 @@ def notify_about_update(user, event_type="UPDATED"):
             url = app.config["ORCID_BASE_URL"] + user.orcid
             send_email(
                 f"""<p>User {user.name} (<a href="{url}" target="_blank">{user.orcid}</a>)
-                {"profile was updated" if event_type == "UPDATED" else "has linked her/his account"} at
+                {"profile was updated" if event_type == "UPDATED" else "has linked their account"} at
                 {(user.updated_at or user.created_at).isoformat(timespec="minutes", sep=' ')}.</p>""",
                 recipient=org.notification_email
                 or (org.tech_contact.name, org.tech_contact.email),

--- a/orcid_hub/views.py
+++ b/orcid_hub/views.py
@@ -1944,7 +1944,7 @@ class ViewMembersAdmin(AppModelView):
                     continue
             except ApiException as ex:
                 if ex.status == 401:
-                    flash(f"User {t.user} has revoked the permissions to update his/her records",
+                    flash(f"User {t.user} has revoked the permissions to update their records",
                           "warning")
                 else:
                     flash(
@@ -2815,7 +2815,7 @@ def section(user_id, section_type="EMP"):
         if not orcid_token:
             orcid_token = OrcidToken.get(user=user, org=current_user.organisation)
     except Exception:
-        flash("User didn't give permissions to update his/her records", "warning")
+        flash("User didn't give permissions to update their records", "warning")
         return redirect(_url)
 
     api = orcid_client.MemberAPIV3(user=user, org=current_user.organisation, access_token=orcid_token.access_token)
@@ -2824,7 +2824,7 @@ def section(user_id, section_type="EMP"):
         api_response = api.get_section(section_type)
     except ApiException as ex:
         if ex.status == 401:
-            flash("User has revoked the permissions to update his/her records", "warning")
+            flash("User has revoked the permissions to update their records", "warning")
         else:
             flash(
                 "Exception when calling ORCID API: \n" + json.loads(ex.body.replace(
@@ -2839,7 +2839,7 @@ def section(user_id, section_type="EMP"):
     try:
         data = json.loads(api_response.data, object_pairs_hook=NestedDict)
     except Exception as ex:
-        flash("User didn't give permissions to update his/her records", "warning")
+        flash("User didn't give permissions to update their records", "warning")
         flash("Unhandled exception occured while retrieving ORCID data: %s" % ex, "danger")
         app.logger.exception(f"For {user} encountered exception")
         return redirect(_url)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -453,7 +453,7 @@ def test_show_record_section(client, mocker):
     ) as view_external_identifiers:
 
         resp = client.get(f"/section/{user.id}/EXR/list", follow_redirects=True)
-        assert b"User didn't give permissions to update his/her records" in resp.data
+        assert b"User didn't give permissions to update their records" in resp.data
 
         resp = client.post(f"/section/{user.id}/EXR/list", follow_redirects=True)
         assert resp.status_code == 200


### PR DESCRIPTION
Given global awareness around gender binary, it seems apposite to replace gendered pronouns with gender-neutral ones.

The use of the possessive form of singular they in place of his/her is comparable to the use by Facebook, Google and others. It seems correct in this context given we don't know the preferred pronouns or gender identity of the target of the messages.