### PR TITLE
Fix security issue in OpenSAML < 3.3.1

### DIFF
--- a/run-app
+++ b/run-app
@@ -72,6 +72,8 @@ if [ -z "$EXTERNAL_SP" ] ; then
 
     echo "Rendering Shibboleth configuration template ..."
     /conf/render_template /conf/templates/shibboleth2.xml >/etc/shibboleth/shibboleth2.xml
+    # https://shibboleth.net/community/advisories/secadv_20250313.txt
+    sed -i -E '/<[^>]+urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign[^>]+/d' /etc/shibboleth/protocols.xml
 
     # Run Shibboleth:
     echo "Starting Shibboleth ..."

--- a/run-app
+++ b/run-app
@@ -72,6 +72,9 @@ if [ -z "$EXTERNAL_SP" ] ; then
 
     echo "Rendering Shibboleth configuration template ..."
     /conf/render_template /conf/templates/shibboleth2.xml >/etc/shibboleth/shibboleth2.xml
+    if [ -f /conf/templates/metadata.xml ] ; then
+        /conf/render_template /conf/templates/metadata.xml >/etc/shibboleth/metadata.xml
+    fi
     # https://shibboleth.net/community/advisories/secadv_20250313.txt
     sed -i -E '/<[^>]+urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign[^>]+/d' /etc/shibboleth/protocols.xml
 


### PR DESCRIPTION
The Shibboleth project published a security issue in Shibboleth native SP (and the underlying OpenSAML library) in March. We fixed this in our local config, but never committed the workaround back.

The underlying issue is explained at https://shibboleth.net/community/advisories/secadv_20250313.txt

The patch implements the workaround described in paragraph five of the recommendations (disabling the SimpleSign mechanism). For most academic federations, this is a non-issue since that mechanism isn't in the SAML2int or eduGAIN profiles.

There's another cosmetic change in the same pull request as a separate patch. That simply allows templating of metadata so that the /Shibboleth.sso/Metadata endpoint produces better output. We've long done this in our instance, and thought it'd be useful to contribute. It's a non-breaking, completely backwards compatible change.